### PR TITLE
option to bring-your-own-binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Cargo.lock
 /example/dist/
 /example/extensions/target/
 /example/*.egg-info
+.idea/
+

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,8 @@ You can define rust extension with `RustExtension` class:
    :param bool debug: Controls whether --debug or --release is passed to cargo. If set to
                       None then build type is auto-detect. Inplace build is debug build
                       otherwise release. Default: None
-
+   :param bool no_binding: If you don't want to run `pyo3` or `rust-cpython`, set this to True.
+                           Useful if you want to use a different interface like CFFI.
 
 Commands
 --------

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -60,7 +60,8 @@ class build_rust(Command):
                 "Can not file rust extension project file: %s" % ext.path)
 
         features = set(ext.features)
-        features.update(cpython_feature(pyo3=ext.pyo3))
+
+        features.update(cpython_feature(pyo3=ext.pyo3, no_binding=ext.no_binding))
 
         if ext.debug is None:
             debug_build = self.inplace
@@ -74,8 +75,9 @@ class build_rust(Command):
         quiet = self.qbuild or ext.quiet
 
         # build cargo command
-        args = (["cargo", "rustc", "--lib", "--manifest-path", ext.path,
-                 "--features", " ".join(features)]
+        feature_args = ["--features" + " ".join(features)] if features else []
+        args = (["cargo", "rustc", "--lib", "--manifest-path", ext.path]
+                + feature_args
                 + list(ext.args or []))
         if not debug_build:
             args.append("--release")

--- a/setuptools_rust/check.py
+++ b/setuptools_rust/check.py
@@ -55,11 +55,12 @@ class check_rust(Command):
                     "Can not file rust extension project file: %s" % ext.path)
 
             features = set(ext.features)
-            features.update(cpython_feature(pyo3=ext.pyo3))
+            features.update(cpython_feature(pyo3=ext.pyo3, no_binding=ext.no_binding))
 
             # build cargo command
-            args = (["cargo", "check", "--lib", "--manifest-path", ext.path,
-                     "--features", " ".join(features)]
+            feature_args = ["--features" + " ".join(features)] if features else []
+            args = (["cargo", "rustc", "--lib", "--manifest-path", ext.path]
+                    + feature_args
                     + list(ext.args or []))
 
             # Execute cargo command

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -29,19 +29,24 @@ class RustExtension:
         None then build type is auto-detect. Inplace build is debug build
         otherwise release. Default: None
       pyo3 : bool
-        Controls wich python binding is in use. `pyo3=True` uses PyO3 binding,
+        Controls which python binding is in use. `pyo3=True` uses PyO3 binding,
         `pyo3=False` uses rust-cpython binding,
+      no_binding : bool
+        If you don't want to run `pyo3` or `rust-cpython`, set this to True.
+        Useful if you want to use a different interface like CFFI.
+
     """
 
     def __init__(self, name, path,
                  args=None, features=None, rust_version=None,
-                 quiet=False, debug=None, pyo3=False):
+                 quiet=False, debug=None, pyo3=False, no_binding=False):
         self.name = name
         self.args = args
         self.pyo3 = pyo3
         self.rust_version = rust_version
         self.quiet = quiet
         self.debug = debug
+        self.no_binding = no_binding
 
         if features is None:
             features = []

--- a/setuptools_rust/test.py
+++ b/setuptools_rust/test.py
@@ -57,7 +57,7 @@ class test_rust(Command):
                     "Can not file rust extension project file: %s" % ext.path)
 
             features = set(ext.features)
-            features.update(cpython_feature(ext=False, pyo3=ext.pyo3))
+            features.update(cpython_feature(ext=False, pyo3=ext.pyo3, no_binding=ext.no_binding))
 
             # build cargo command
             args = (["cargo", "test", '--color', 'always', "--manifest-path",

--- a/setuptools_rust/utils.py
+++ b/setuptools_rust/utils.py
@@ -6,7 +6,9 @@ from distutils.errors import DistutilsPlatformError
 import semantic_version
 
 
-def cpython_feature(ext=True, pyo3=False):
+def cpython_feature(ext=True, pyo3=False, no_binding=False):
+    if no_binding:
+        return ()
     version = sys.version_info
 
     if pyo3:


### PR DESCRIPTION
@fafhrd91 What do you think about providing an option to avoid using rust-cpython or pyo3? 
Are you even the right project to talk to? I know nothing about PyO3 but it just seemed like this was the most actively developed Setuptools plugin for Rust. 

I'm making a cookiecutter project to enable cross-platform build and publish of Python wheels that have rust extensions and I used CFFI instead of those two. I needed to make this fork to unblock myself.

The new Cookiecutter is here https://github.com/mckaymatt/cookiecutter-pypackage-rust-cross-platform-publish and example output is here https://github.com/mckaymatt/trust_pypi_example specifically here https://github.com/mckaymatt/trust_pypi_example/blob/master/requirements_dev.txt#L15
