### PR TITLE
binding options as an enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Cargo.lock
 /example/dist/
 /example/extensions/target/
 /example/*.egg-info
+.idea/

--- a/setuptools_rust/__init__.py
+++ b/setuptools_rust/__init__.py
@@ -7,6 +7,7 @@ from .check import check_rust
 from .clean import clean_rust
 from .test import test_rust
 from .extension import RustExtension
+from .utils import Binding
 
 __all__ = ('RustExtension',
            'check_rust', 'clean_rust', 'build_ext', 'build_rust', 'test_rust')

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -60,7 +60,7 @@ class build_rust(Command):
                 "Can not file rust extension project file: %s" % ext.path)
 
         features = set(ext.features)
-        features.update(cpython_feature(pyo3=ext.pyo3))
+        features.update(cpython_feature(binding=ext.binding))
 
         if ext.debug is None:
             debug_build = self.inplace
@@ -74,8 +74,9 @@ class build_rust(Command):
         quiet = self.qbuild or ext.quiet
 
         # build cargo command
-        args = (["cargo", "rustc", "--lib", "--manifest-path", ext.path,
-                 "--features", " ".join(features)]
+        feature_args = ["--features " + " ".join(features)] if features else []
+        args = (["cargo", "rustc", "--lib", "--manifest-path", ext.path]
+                + feature_args
                 + list(ext.args or []))
         if not debug_build:
             args.append("--release")
@@ -158,7 +159,7 @@ class build_rust(Command):
             rust_version = ext.get_rust_version()
             if rust_version is not None and version not in rust_version:
                 raise DistutilsPlatformError(
-                    "Rust %s does not match extension requirenment %s" % (
+                    "Rust %s does not match extension requirement %s" % (
                         version, ext.rust_version))
 
             self.build_extension(ext)

--- a/setuptools_rust/check.py
+++ b/setuptools_rust/check.py
@@ -55,11 +55,12 @@ class check_rust(Command):
                     "Can not file rust extension project file: %s" % ext.path)
 
             features = set(ext.features)
-            features.update(cpython_feature(pyo3=ext.pyo3))
+            features.update(cpython_feature(binding=ext.binding))
 
             # build cargo command
-            args = (["cargo", "check", "--lib", "--manifest-path", ext.path,
-                     "--features", " ".join(features)]
+            feature_args = ["--features" + " ".join(features)] if features else []
+            args = (["cargo", "rustc", "--lib", "--manifest-path", ext.path]
+                    + feature_args
                     + list(ext.args or []))
 
             # Execute cargo command

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -2,6 +2,8 @@ from __future__ import print_function, absolute_import
 import os
 import sys
 from distutils.errors import DistutilsSetupError
+from .utils import Binding
+
 
 import semantic_version
 
@@ -28,17 +30,19 @@ class RustExtension:
         Controls whether --debug or --release is passed to cargo. If set to
         None then build type is auto-detect. Inplace build is debug build
         otherwise release. Default: None
-      pyo3 : bool
-        Controls wich python binding is in use. `pyo3=True` uses PyO3 binding,
-        `pyo3=False` uses rust-cpython binding,
+      binding : setuptools_rust.Binding
+        Controls which python binding is in use.
+        Binding.PyO3 uses PyO3
+        Binding.RustCPython uses Rust CPython.
+        Binding.NoBinding uses no binding.
     """
 
     def __init__(self, name, path,
                  args=None, features=None, rust_version=None,
-                 quiet=False, debug=None, pyo3=False):
+                 quiet=False, debug=None, binding=Binding.PyO3):
         self.name = name
         self.args = args
-        self.pyo3 = pyo3
+        self.binding = binding
         self.rust_version = rust_version
         self.quiet = quiet
         self.debug = debug

--- a/setuptools_rust/test.py
+++ b/setuptools_rust/test.py
@@ -57,17 +57,18 @@ class test_rust(Command):
                     "Can not file rust extension project file: %s" % ext.path)
 
             features = set(ext.features)
-            features.update(cpython_feature(ext=False, pyo3=ext.pyo3))
+            features.update(cpython_feature(ext=False, binding=ext.binding))
 
             # build cargo command
-            args = (["cargo", "test", '--color', 'always', "--manifest-path",
-                     ext.path, "--features", " ".join(features)]
+            feature_args = ["--features " + " ".join(features)] if features else []
+            args = (["cargo", "rustc", "--lib", "--manifest-path", ext.path]
+                    + feature_args
                     + list(ext.args or []))
 
             # Execute cargo command
             print(' '.join(args))
             try:
-                subprocess.check_output(args)
+                subprocess.check_output(args, env=env)
             except subprocess.CalledProcessError as e:
                 raise CompileError(
                     "cargo failed with code: %d\n%s" % (

--- a/setuptools_rust/utils.py
+++ b/setuptools_rust/utils.py
@@ -6,15 +6,29 @@ from distutils.errors import DistutilsPlatformError
 import semantic_version
 
 
-def cpython_feature(ext=True, pyo3=False):
+class Binding:
+    """
+    Binding Options
+    """
+    #  https://github.com/PyO3/PyO3
+    PyO3 = 0
+    #  https://github.com/dgrunwald/rust-cpython
+    RustCPython = 1
+    #  Bring your own binding
+    NoBinding = 2
+
+
+def cpython_feature(ext=True, binding=Binding.PyO3):
     version = sys.version_info
 
-    if pyo3:
+    if binding is Binding.NoBinding:
+        return ()
+    elif binding is Binding.PyO3:
         if ext:
             return ("pyo3/extension-module",)
         else:
             return ()
-    else:
+    elif binding is Binding.RustCPython:
         if (2, 7) < version < (2, 8):
             if ext:
                 return ("cpython/python27-sys", "cpython/extension-module-2-7")
@@ -25,10 +39,11 @@ def cpython_feature(ext=True, pyo3=False):
                 return ("cpython/python3-sys", "cpython/extension-module")
             else:
                 return ("cpython/python3-sys",)
-
-    raise DistutilsPlatformError(
-        "Unsupported python version: %s" % sys.version)
-
+        else:
+            raise DistutilsPlatformError(
+                "Unsupported python version: %s" % sys.version)
+    else:
+        raise DistutilsPlatformError('Unknown Binding: "{}" '.format(binding))
 
 def get_rust_version():
     try:


### PR DESCRIPTION
how about this @fafhrd91 
see  https://github.com/PyO3/setuptools-rust/pull/9

I can get my package to work with these changes, but I can't get the example in the repo to work. It doesn't look like you actually pull in the PyO3 bindings in the .toml file. 

