### PR TITLE
Improve compatibility of `build_rust` with `build_ext`

### DIFF
--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -186,8 +186,8 @@ class build_rust(Command):
                 dylib_ext = "dylib"
             else:
                 dylib_ext = "so"
-            ext.basename = ext.name.rsplit('.', 1)[-1]
-            wildcard_so = "*{}.{}".format(ext.basename, dylib_ext)
+
+            wildcard_so = "*{}.{}".format(ext.get_lib_name(), dylib_ext)
 
             try:
                 dylib_paths.append((

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -181,17 +181,19 @@ class build_rust(Command):
                     target_dir)
         else:
             if sys.platform == "win32":
-                wildcard_so = "*.dll"
+                dylib_ext = "dll"
             elif sys.platform == "darwin":
-                wildcard_so = "*.dylib"
+                dylib_ext = "dylib"
             else:
-                wildcard_so = "*.so"
+                dylib_ext = "so"
+            wildcard_so = "*{}.{}".format(ext.basename, dylib_ext)
 
             try:
-                dylib_paths.append(
-                    (ext.name, glob.glob(
-                        os.path.join(artifactsdir, wildcard_so))[0]))
-            except IndexError:
+                dylib_paths.append((
+                    ext.name,
+                    next(glob.iglob(os.path.join(artifactsdir, wildcard_so)))
+                ))
+            except StopIteration:
                 raise DistutilsExecError(
                     "rust build failed; unable to find any %s in %s" %
                     (wildcard_so, artifactsdir))

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -186,6 +186,7 @@ class build_rust(Command):
                 dylib_ext = "dylib"
             else:
                 dylib_ext = "so"
+            ext.basename = ext.name.rsplit('.', 1)[-1]
             wildcard_so = "*{}.{}".format(ext.basename, dylib_ext)
 
             try:

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -5,6 +5,11 @@ import sys
 from distutils.errors import DistutilsSetupError
 from .utils import Binding, Strip
 
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+
 
 import semantic_version
 
@@ -90,6 +95,11 @@ class RustExtension:
                 os.chdir(cwd)
 
         self.path = path
+
+    def get_lib_name(self):
+        cfg = configparser.ConfigParser()
+        cfg.read(self.path)
+        return cfg.get('lib', 'name').strip('"')
 
     def get_rust_version(self):
         if self.rust_version is None:


### PR DESCRIPTION
### Rationale

The behaviour of `build_ext` is the following: when generating compilation 
artifacts (such as `.o` files), it will put them in a directory defined by the 
`build_temp` argument, and within that directory create a directory named after 
the project name in `setup.py`, and them dump its temporary files there.

The only way to do that with `build_rust` was through editing the 
`CARGO_TARGET_DIR` environment variable, but this is not practical and also does 
not comply well with the different available configuration files (`setup.cfg`, 
user `distutils.cfg` and the like).

### Implementation

* if the user gives the `--build-temp` argument to the CLI, or sets `build_temp` 
within the `[build]`, `[build_ext]` or `[build_rust]` sections of any 
configuration file, then cargo will use that directory as a target directory.
* if no directory is set, then cargo will use the default `build_temp` (which is 
`build/temp.<platform>-<version>`).
* if `CARGO_TARGET_DIR` is set, then it will overwrite any python-defined setting 
and build to that directory directly.

I also made `build_rust` inherit from `build_ext` the following options: `inplace` 
and `debug`.

### Perks

* if a library has more than one extension modules with `Cargo.toml` files in 
different subdirectories, cargo would create a local target directory for each 
library, and thus rebuild several times the same cargo modules (for instance, 
`PyO3` !)
* removes the need for a `clean_rust` command, since `python setup.py clean` 
removes the `build_temp` directory
* fixes #27 :wink: 
* fixes the following error: when `CARGO_TARGET_DIR` is set, and multiple extensions are built for a project, the wrong library can be copied (since `build_rust` did not check for the library name beforehand)

### Drawbacks

* not really backwards compatible