### PR TITLE
Fix problem with configparser being unable to handle "arrays of tables" in Cargo.toml 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Cargo.lock
 /example/target/
 /example/*.egg-info
 .idea/
+.mypy_cache/

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         (open('README.rst').read(), open('CHANGES.rst').read())),
     license='MIT',
     packages=['setuptools_rust'],
-    install_requires=['semantic_version>=2.6.0'],
+    install_requires=['semantic_version>=2.6.0', 'toml>=0.9.0'],
     zip_safe=True,
     classifiers=[
         "Topic :: Software Development :: Version Control",


### PR DESCRIPTION
The toml parsing section of `setuptools_rust` in `extension.py` was unable to parse my `Cargo.toml` (shown below). It seems the reason is that `configparser` is unable to handle [Arrays of Tables](https://github.com/toml-lang/toml#array-of-tables) like `[[bench]]` or `[[example]]`. Although it adds a dependency, I switched out `configparser` with the [`toml package`](https://github.com/uiri/toml) and that seems to have fixed the problem.

Current code in `extension.py`:
```
def get_lib_name(self):
    cfg = configparser.ConfigParser()
    cfg.read(self.path)
    section = 'lib' if cfg.has_option('lib', 'name') else 'package'
    name = cfg.get(section, 'name').strip('\'\"').strip()
    return re.sub(r"[./\\-]", "_", name)
```

My `Cargo.toml` that `configparser` was unable to handle:
```
[package]
name = "argonautica"
version = "0.1.0" # remember to update html_root_url

authors = ["Brian Myers <brian.carl.myers@gmail.com>"]
categories = ["Algorithms", "API bindings", "Authentication", "Cryptography"]
description = "Idiomatic Argon2 password hashing for Rust"
documentation = "https://docs.rs/argonautica"
homepage = "https://github.com/bcmyers/argonautica"
keywords = ["argon2", "argon2d", "argon2i", "argon2id", "crypto", "cryptography", "hash", "hashing", "password", "security"]
license = "MIT/Apache-2.0"
publish = false # TODO
readme = "README.md"
repository = "https://github.com/bcmyers/argonautica"

build = "build.rs"
links = "argon2"

[lib]
name = "argonautica"
crate_type = ["lib", "cdylib"]

[features]
actix_web = ["actix-web", "env_logger", "futures-timer", "serde"]
benches = ["argon2rs", "criterion", "md5", "native", "rust-argon2", "sha2", "simd"]
development = ["bindgen", "blake2-rfc", "cbindgen", "tempdir"]
native = []
simd = []

[dependencies]
base64 = "0.9"
bitflags = "1.0"
failure = "0.1"
futures = "0.1"
futures-cpupool = "0.1"
libc = "0.2"
log = "0.4"
nom = "4.0"
num_cpus = "1.8"
rand = "0.5"
scopeguard = "0.3"
serde = { version = "1.0", optional = true, features = ["derive"] }

# benches
argon2rs = { version = "0.2.5", optional = true }
criterion = { version = "0.2", optional = true }
md5 = { version = "0.3.7", optional = true }
rust-argon2 = { version = "0.3.0", optional = true }
sha2 = { version = "0.7.1", optional = true }

# development
bindgen = { version = "0.37", optional = true }
blake2-rfc = { version = "0.2", optional = true }
cbindgen = { version = "0.6", optional = true }
tempdir = { version = "0.3", optional = true }

# example_actix_web
actix-web = { version = "0.6", optional = true }
env_logger = { version = "0.5", optional = true }
futures-timer = { version = "0.1", optional = true }

[build-dependencies]
bindgen = "0.37"
cbindgen = "0.6"
cfg-if = "0.1"
cc = { version = "1.0.15", features = ["parallel"] }
failure = "0.1"
tempdir = "0.3"

[dev-dependencies]
dotenv = "0.13"
lazy_static = "1.0"
serde_json = "1.0"

[[bench]]
name = "bench_crates"
harness = false
required-features = ["benches"]

[[bench]]
name = "bench_fast_but_insecure"
harness = false
required-features = ["benches"]

[[bench]]
name = "bench_inputs"
harness = false
required-features = ["benches"]

[[bench]]
name = "bench_threads"
harness = false
required-features = ["benches"]

[[bin]]
name = "generate_bindings"
path = "src/bin/generate_bindings.rs"
required-features = ["development"]

[[bin]]
name = "generate_header"
path = "src/bin/generate_header.rs"
required-features = ["development"]

[[bin]]
name = "foo"
path = "src/bin/foo.rs"

[[example]]
name = "calibrate_timing"
path = "examples/calibrate_timing.rs"

[[example]]
name = "example_actix_web"
path = "examples/example_actix_web.rs"
required-features = ["actix_web"]

[[example]]
name = "example_custom"
path = "examples/example_custom.rs"

[[example]]
name = "example_non_blocking"
path = "examples/example_non_blocking.rs"

[[example]]
name = "example_serde"
path = "examples/example_serde.rs"
required-features = ["serde"]

[[example]]
name = "example_simple"
path = "examples/example_simple.rs"

[[example]]
name = "example_very_simple"
path = "examples/example_very_simple.rs"

[[example]]
name = "generate_secret_key"
path = "examples/generate_secret_key.rs"

[badges]
travis-ci = { repository = "bcmyers/argonautica", branch = "master" }
```

Error that I got when running `python setup.py bdist_wheel`:
```
configparser.DuplicateSectionError: While reading from 'Cargo.toml' [line 80]: section '[bench' already exists
```