### PR TITLE
Make sure that cargo uses --verbose option if pip install defines it

### DIFF
--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -123,6 +123,9 @@ class build_rust(Command):
                 args.append("--release")
             if quiet:
                 args.append("-q")
+            elif self.verbose:
+                args.append("--verbose")
+
         else:
             args = (
                 ["cargo", "rustc", "--lib", "--manifest-path", ext.path]
@@ -133,6 +136,8 @@ class build_rust(Command):
                 args.append("--release")
             if quiet:
                 args.append("-q")
+            elif self.verbose:
+                args.append("--verbose")
 
             args.extend(["--", "--crate-type", "cdylib"])
             args.extend(ext.rustc_flags or [])


### PR DESCRIPTION
The objective of this pull request is to allow cargo verbose build if `build_rust` is executed with the `--verbose` flag.
This could be useful in case of issues while building a python rust binding. 


An example could be while building a binding via CI (travos, appveyor,...), if the build fails because of linking issues without this PR would be hard to determine exactly where the problem is, instead you could rerun the build with extra verbosity and will probably get valuable information to fix the issue or at least to try to replicate it locally