### PR TITLE
Fix CI failing because of Cargo.toml format change

### DIFF
--- a/example_tomlgen/setup.cfg
+++ b/example_tomlgen/setup.cfg
@@ -10,7 +10,7 @@ zip_safe = false
 create_workspace = true
 
 [tomlgen_rust.dependencies]
-pyo3 = { git = "https://github.com/PyO3/pyo3", features = ["extension-module"] }
+pyo3 = { version = "0.5.0-alpha.3", features = ["extension-module"] }
 
 [tomlgen_rust.dependencies.hello-english]
 english-lint = "*"

--- a/example_tomlgen/setup.cfg
+++ b/example_tomlgen/setup.cfg
@@ -10,7 +10,7 @@ zip_safe = false
 create_workspace = true
 
 [tomlgen_rust.dependencies]
-pyo3 = { version = "0.4", features = ["extension-module"] }
+pyo3 = { git = "https://github.com/PyO3/pyo3", features = ["extension-module"] }
 
 [tomlgen_rust.dependencies.hello-english]
 english-lint = "*"

--- a/setuptools_rust/tomlgen.py
+++ b/setuptools_rust/tomlgen.py
@@ -118,7 +118,7 @@ class tomlgen_rust(setuptools.Command):
 
                     config.write("[build]\n")
                     config.write(
-                        'target-dir = "{}"\n'.format(os.path.relpath(targetdir, cfgdir))
+                        'target-dir = "{}"\n'.format(os.path.relpath(targetdir))
                     )
 
             else:

--- a/setuptools_rust/tomlgen.py
+++ b/setuptools_rust/tomlgen.py
@@ -143,7 +143,7 @@ class tomlgen_rust(setuptools.Command):
 
         # Create a small package section
         toml.add_section("package")
-        toml.set("package", "name", quote(ext.name))
+        toml.set("package", "name", quote(ext.name.replace('.', '-')))
         toml.set("package", "version", quote(dist.get_version()))
         toml.set("package", "authors", self.authors)
         toml.set("package", "publish", "false")


### PR DESCRIPTION
Rust used to support crate names in `Cargo.toml` containing dots, but doesn't anymore. This means the extension name cannot be used as a crate name, so it is escaped with dashes instead of dots (unless someone has a better idea ?).

I also patched `example_tomlgen/Cargo.toml` to use the git version of PyO3 instead of the v4 which does not build successfully.