### PR TITLE
Fix python-publish workflow type

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,7 +5,8 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
I made the `0.11` release as a draft, and then published, but the action did not run.

From [this stackoverflow post](https://stackoverflow.com/questions/59319281/github-action-different-between-release-created-and-published) I think that might be expected with `created` type, so it's better to use `published`.

I've also added the `workflow_dispatch` to manually trigger this, so I can get the release pushed. I'll remove it once the release is done.