### PR TITLE
Also fetch tag history when releasing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Fetch all history so that setuptools_scm works correctly
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
The previous attempt to release `0.11` failed, I believe because the default actions checkout is shallow. https://github.com/PyO3/setuptools-rust/runs/953629161?check_suite_focus=true

This change should rectify that.