### PR TITLE
Avoid f-strings for now

### DIFF
--- a/setuptools_rust/tomlgen.py
+++ b/setuptools_rust/tomlgen.py
@@ -188,7 +188,7 @@ class tomlgen_rust(setuptools.Command):
         for section in sections:
             if self.cfg.has_section(section):
                 for dep, options in self.cfg.items(section):
-                    yield dep, toml.loads(f"{dep} = {options}")[dep]
+                    yield dep, toml.loads("%s = %s" % (dep, options))[dep]
 
 
 def _slugify(name):


### PR DESCRIPTION
This commit removes the use of f strings from tomlgen module. The package
metadata didn't set a minimum python version and fstrings don't work
with python 3.5. To enable having the last release of setuptools-rust
prior to setting the python_requires work with python 3.5 we need to
have a release which will work for 3.5. With this change setuptools-rust
should work fine with Python 3.5. So we can release this and then set
the minimum supported python version to 3.6 and reintroduce the use of
fstrings.

Fixes #85