### PR TITLE
Use target CARGO_BUILD_TARGET if specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+ - Respect `CARGO_BUILD_TARGET` environment variable if set. [#90](https://github.com/PyO3/setuptools-rust/pull/90)
+
 ## 0.11.5 (2020-11-10)
 
  - Fix support for Python 3.5. [#86](https://github.com/PyO3/setuptools-rust/pull/86)

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -92,10 +92,14 @@ class build_rust(Command):
 
         # If we are on a 64-bit machine, but running a 32-bit Python, then
         # we'll target a 32-bit Rust build.
+        # Automatic target detection can be overridden via the CARGO_BUILD_TARGET
+        # environment variable.
         # TODO: include --target for all platforms so env vars can't break the build
         target_triple = None
         target_args = []
-        if self.plat_name == "win32":
+        if os.getenv("CARGO_BUILD_TARGET"):
+            target_triple = os.environ["CARGO_BUILD_TARGET"]
+        elif self.plat_name == "win32":
             target_triple = "i686-pc-windows-msvc"
         elif self.plat_name == "win-amd64":
             target_triple = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
We ran into a [build issue on conda-forge](https://github.com/conda-forge/tokenizers-feedstock/pull/8#issuecomment-723472759) recently, where setuptools-rust does not pick up that a CARGO_BUILD_TARGET environment variable is set. The effect of this is that the rust compilation step succeeds, but the build artifacts land in a `.../target/x86_64-unknown-linux-gnu/release/...` path. `setuptools-rust` still looks for them in the `.../target/release/...` parth though, which the fails the build.

This change might fix the issue. I haven't tested it though, and I'm not a rust developer.