### PR TITLE
Remove README.rst from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include README.md
-include README.rst
 include CHANGELOG.md
 include LICENSE


### PR DESCRIPTION
``MANIFEST.in`` is referencing non-existing file ``README.rst``.

```
reading manifest template 'MANIFEST.in'
warning: no files found matching 'README.rst'
```

Signed-off-by: Christian Heimes <christian@python.org>