### PR TITLE
Add version information to setup.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ build
 target
 .pytest_cache
 *.egg-info
+setuptools_rust/version.py
 pyo3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
  - Respect `CARGO_BUILD_TARGET` environment variable if set. [#90](https://github.com/PyO3/setuptools-rust/pull/90)
+ - Add `setuptools_rust.__version__` and require setuptools >= 46.1. [#91](https://github.com/PyO3/setuptools-rust/issues/91)
 
 ## 0.11.5 (2020-11-10)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools>=41", "wheel", "setuptools_scm[toml]>=3.4.3"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+write_to = "setuptools_rust/version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = setuptools-rust
+version = attr: setuptools_rust.__version__
 author = Nikolay Kim
 author_email = fafhrd91@gmail.com
 license = MIT
@@ -27,7 +28,7 @@ classifiers =
 packages = setuptools_rust
 zip_safe = True
 install_requires = semantic_version>=2.6.0; toml>=0.9.0
-setup_requires = setuptools>=41; wheel; setuptools_scm[toml]>=3.4.3
+setup_requires = setuptools>=46.1; wheel; setuptools_scm[toml]>=3.4.3
 
 [options.entry_points]
 distutils.commands =

--- a/setuptools_rust/__init__.py
+++ b/setuptools_rust/__init__.py
@@ -8,6 +8,8 @@ from .test import test_rust
 from .tomlgen import tomlgen_rust, find_rust_extensions
 from .utils import Binding, Strip
 
+__version__ = "0.11.6.dev1"
+
 __all__ = (
     "RustExtension",
     "Binding",

--- a/setuptools_rust/__init__.py
+++ b/setuptools_rust/__init__.py
@@ -7,8 +7,8 @@ from .extension import RustExtension
 from .test import test_rust
 from .tomlgen import tomlgen_rust, find_rust_extensions
 from .utils import Binding, Strip
+from .version import version as __version__
 
-__version__ = "0.11.6.dev1"
 
 __all__ = (
     "RustExtension",


### PR DESCRIPTION
- add `setuptools_rust.__version__`
- populate setup.cfg's version field from `setuptools_rust.__version__`
- require setuptools >= 46.1

Version ``0.11.6.dev1`` means that the current main branch is in
development phase of an upcoming 0.11.6 release.

Resolves: https://github.com/PyO3/setuptools-rust/issues/91
Signed-off-by: Christian Heimes <christian@python.org>