### PR TITLE
Add runtime dependency on setuptools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Respect `PYO3_PYTHON` and `PYTHON_SYS_EXECUTABLE` environment variables if set. [#96](https://github.com/PyO3/setuptools-rust/pull/96)
+- Add runtime dependency on setuptools >= 46.1. [#102](https://github.com/PyO3/setuptools-rust/pull/102)
 
 ## 0.11.6 (2020-12-13)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4.3"]
+requires = ["setuptools>=46.1", "wheel", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 packages = setuptools_rust
 zip_safe = True
-install_requires = semantic_version>=2.6.0; toml>=0.9.0
+install_requires = setuptools>=46.1; semantic_version>=2.6.0; toml>=0.9.0
 setup_requires = setuptools>=46.1; wheel; setuptools_scm[toml]>=3.4.3
 
 [options.entry_points]


### PR DESCRIPTION
setuptools_rust has a runtime dependency on setuptools. Ensure that all
installations of setuptools_rust have a sufficiently recent version of
setuptools.

Fixes: https://github.com/PyO3/setuptools-rust/issues/101
Signed-off-by: Christian Heimes <christian@python.org>