### PR TITLE
Augment, rather than replace, existing RUSTFLAGS when building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Respect `PYO3_PYTHON` and `PYTHON_SYS_EXECUTABLE` environment variables if set. [#96](https://github.com/PyO3/setuptools-rust/pull/96)
 - Add runtime dependency on setuptools >= 46.1. [#102](https://github.com/PyO3/setuptools-rust/pull/102)
+- Append to, rather than replace, existing RUSTFLAGS when building. [#103](https://github.com/PyO3/setuptools-rust/pull/103)
 
 ## 0.11.6 (2020-12-13)
 

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -186,7 +186,7 @@ class build_rust(Command):
             rustflags += " -C target-cpu=native"
 
         if rustflags:
-            env["RUSTFLAGS"] = rustflags
+            env["RUSTFLAGS"] = (env.get("RUSTFLAGS", "") + " " + rustflags).strip()
 
         # Execute cargo
         try:


### PR DESCRIPTION
Some complex environments may use RUSTFLAGS to control the behavior of rust compilation. Rather than overwriting RUSTFLAGS with custom flags, augment any existing RUSTFLAGS to preserve these environments.

This is used, for example, by Void Linux to set `--sysroot=${XBPS_CROSS_BASE}/usr` in cross-compilation environments to point to the target system root.