### PR TITLE
Shared libraries also need executable bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Respect `PYO3_PYTHON` and `PYTHON_SYS_EXECUTABLE` environment variables if set. [#96](https://github.com/PyO3/setuptools-rust/pull/96)
 - Add runtime dependency on setuptools >= 46.1. [#102](https://github.com/PyO3/setuptools-rust/pull/102)
 - Append to, rather than replace, existing RUSTFLAGS when building. [#103](https://github.com/PyO3/setuptools-rust/pull/103)
+- Set executable bit on shared library. [#110](https://github.com/PyO3/setuptools-rust/pull/110)
 
 ## 0.11.6 (2020-12-13)
 

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -325,11 +325,11 @@ class build_rust(Command):
                     except subprocess.CalledProcessError as e:
                         pass
 
-            # executables and win32(cygwin)-dll's need X bits
-            if executable or sys.platform == "win32" or sys.platform == "cygwin":
-                mode = os.stat(ext_path).st_mode
-                mode |= (mode & 0o444) >> 2  # copy R bits to X
-                os.chmod(ext_path, mode)
+            # executables, win32(cygwin)-dll's, and shared libraries on
+            # Unix-like operating systems need X bits
+            mode = os.stat(ext_path).st_mode
+            mode |= (mode & 0o444) >> 2  # copy R bits to X
+            os.chmod(ext_path, mode)
 
     def run(self):
         if not self.extensions:


### PR DESCRIPTION
Shared libraries on Linux, macOS, and other Unix-like operating systems
require the executable bit, too.

Fixes: https://github.com/PyO3/setuptools-rust/issues/109
Signed-off-by: Christian Heimes <christian@python.org>