### PR TITLE
Don't require optional wheel dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add runtime dependency on setuptools >= 46.1. [#102](https://github.com/PyO3/setuptools-rust/pull/102)
 - Append to, rather than replace, existing RUSTFLAGS when building. [#103](https://github.com/PyO3/setuptools-rust/pull/103)
 - Set executable bit on shared library. [#110](https://github.com/PyO3/setuptools-rust/pull/110)
+- Don't require optional wheel dependency. [#111](https://github.com/PyO3/setuptools-rust/pull/111)
 
 ## 0.11.6 (2020-12-13)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=46.1", "wheel", "setuptools_scm[toml]>=3.4.3"]
+requires = ["setuptools>=46.1", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 packages = setuptools_rust
 zip_safe = True
 install_requires = setuptools>=46.1; semantic_version>=2.6.0; toml>=0.9.0
-setup_requires = setuptools>=46.1; wheel; setuptools_scm[toml]>=3.4.3
+setup_requires = setuptools>=46.1; setuptools_scm[toml]>=3.4.3
 
 [options.entry_points]
 distutils.commands =


### PR DESCRIPTION
This seems to only be required for building binary wheels, so it should not be a hard requirement.

FYI I hit this issue when trying to port setuptools-rust to [buildroot](https://buildroot.org/) due to [cryptography](https://github.com/pyca/cryptography) starting to require rust, buildroot deliberately does not support binary python wheels as python packages are cross compiled from source.