### PR TITLE
Support building x86-64 wheel on arm64 macOS machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Append to, rather than replace, existing RUSTFLAGS when building. [#103](https://github.com/PyO3/setuptools-rust/pull/103)
 - Set executable bit on shared library. [#110](https://github.com/PyO3/setuptools-rust/pull/110)
 - Don't require optional wheel dependency. [#111](https://github.com/PyO3/setuptools-rust/pull/111)
+- Support building x86-64 wheel on arm64 macOS machine. [#114](https://github.com/PyO3/setuptools-rust/pull/114)
 
 ## 0.11.6 (2020-12-13)
 

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import
 import glob
 import json
 import os
+import platform
 import shutil
 import sys
 import subprocess
@@ -103,6 +104,9 @@ class build_rust(Command):
             target_triple = "i686-pc-windows-msvc"
         elif self.plat_name == "win-amd64":
             target_triple = "x86_64-pc-windows-msvc"
+        elif self.plat_name.startswith("macosx-") and platform.machine() == "x86_64":
+            # x86_64 or arm64 macOS targeting x86_64
+            target_triple = "x86_64-apple-darwin"
 
         if target_triple is not None:
             target_args = ["--target", target_triple]


### PR DESCRIPTION
This makes `arch -x86_64 python3.9 setup.py build_ext` works on Apple Silicon Macs.

cc #108 @ronaldoussoren