### PR TITLE
refactoring: tidy up library and reuse more logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
 ## Unreleased
+### Packaging
+- Bump minimum Python version to Python 3.6.
 
+### Changed
 - Respect `PYO3_PYTHON` and `PYTHON_SYS_EXECUTABLE` environment variables if set. [#96](https://github.com/PyO3/setuptools-rust/pull/96)
 - Add runtime dependency on setuptools >= 46.1. [#102](https://github.com/PyO3/setuptools-rust/pull/102)
-- Append to, rather than replace, existing RUSTFLAGS when building. [#103](https://github.com/PyO3/setuptools-rust/pull/103)
+- Append to, rather than replace, existing `RUSTFLAGS` when building. [#103](https://github.com/PyO3/setuptools-rust/pull/103)
+
+### Fixed
 - Set executable bit on shared library. [#110](https://github.com/PyO3/setuptools-rust/pull/110)
-- Don't require optional wheel dependency. [#111](https://github.com/PyO3/setuptools-rust/pull/111)
+- Don't require optional `wheel` dependency. [#111](https://github.com/PyO3/setuptools-rust/pull/111)
 
 ## 0.11.6 (2020-12-13)
 

--- a/examples/namespace_package/Cargo.lock
+++ b/examples/namespace_package/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "namespace_package_bar"
+name = "namespace_package_rust"
 version = "0.1.0"
 dependencies = [
  "pyo3",

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ version = attr: setuptools_rust.__version__
 author = Nikolay Kim
 author_email = fafhrd91@gmail.com
 license = MIT
-description = Setuptools rust extension plugin
+description = Setuptools Rust extension plugin
 keywords = distutils, setuptools, rust
 url = https://github.com/PyO3/setuptools-rust
 long_description = file: README.md
@@ -29,6 +29,7 @@ packages = setuptools_rust
 zip_safe = True
 install_requires = setuptools>=46.1; semantic_version>=2.6.0; toml>=0.9.0
 setup_requires = setuptools>=46.1; setuptools_scm[toml]>=3.4.3
+python_requires = >=3.6
 
 [options.entry_points]
 distutils.commands =

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,4 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup(
-        python_requires='>=3.5'
-    )
+    setup()

--- a/setuptools_rust/__init__.py
+++ b/setuptools_rust/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import
-
 from .build import build_rust
 from .check import check_rust
 from .clean import clean_rust

--- a/setuptools_rust/clean.py
+++ b/setuptools_rust/clean.py
@@ -1,40 +1,27 @@
-from __future__ import print_function, absolute_import
 import sys
 import subprocess
-from distutils.cmd import Command
 
+from .command import RustCommand
 from .extension import RustExtension
 
+class clean_rust(RustCommand):
+    """Clean Rust extensions. """
 
-class clean_rust(Command):
-    """ Clean rust extensions. """
-
-    description = "clean rust extensions (compile/link to build directory)"
+    description = "clean Rust extensions (compile/link to build directory)"
 
     def initialize_options(self):
-        self.extensions = ()
+        super().initialize_options()
         self.inplace = False
 
-    def finalize_options(self):
-        self.extensions = [
-            ext
-            for ext in self.distribution.rust_extensions
-            if isinstance(ext, RustExtension)
-        ]
+    def run_for_extension(self, ext: RustExtension):
+        # build cargo command
+        args = ["cargo", "clean", "--manifest-path", ext.path]
 
-    def run(self):
-        if not self.extensions:
-            return
+        if not ext.quiet:
+            print(" ".join(args), file=sys.stderr)
 
-        for ext in self.extensions:
-            # build cargo command
-            args = ["cargo", "clean", "--manifest-path", ext.path]
-
-            if not ext.quiet:
-                print(" ".join(args), file=sys.stderr)
-
-            # Execute cargo command
-            try:
-                subprocess.check_output(args)
-            except:
-                pass
+        # Execute cargo command
+        try:
+            subprocess.check_output(args)
+        except:
+            pass

--- a/setuptools_rust/command.py
+++ b/setuptools_rust/command.py
@@ -1,0 +1,55 @@
+from abc import ABC, abstractmethod
+
+from distutils.cmd import Command
+from distutils.errors import DistutilsPlatformError
+
+from .extension import RustExtension
+from .utils import get_rust_version
+
+class RustCommand(Command, ABC):
+    """Abstract base class for commands which interact with Rust Extensions."""
+
+    def initialize_options(self):
+        self.extensions = ()
+
+    def finalize_options(self):
+        self.extensions = [
+            ext
+            for ext in self.distribution.rust_extensions
+            if isinstance(ext, RustExtension)
+        ]
+
+    def run(self):
+        if not self.extensions:
+            return
+
+        all_optional = all(ext.optional for ext in self.extensions)
+        try:
+            version = get_rust_version()
+        except DistutilsPlatformError as e:
+            if not all_optional:
+                raise
+            else:
+                print(str(e))
+                return
+
+        for ext in self.extensions:
+            try:
+                rust_version = ext.get_rust_version()
+                if rust_version is not None and version not in rust_version:
+                    raise DistutilsPlatformError(
+                        f"Rust {version} does not match extension requirement {rust_version}"
+                    )
+
+                self.run_for_extension(ext)
+            except Exception as e:
+                if not ext.optional:
+                    raise
+                else:
+                    command_name = self.get_command_name()
+                    print(f"{command_name}: optional Rust extension {ext.name} failed")
+                    print(str(e))
+
+    @abstractmethod
+    def run_for_extension(self, extension: RustExtension) -> None:
+        ...

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import
 import os
 import re
 from distutils.errors import DistutilsSetupError
@@ -100,16 +99,6 @@ class RustExtension:
 
         # get relative path to Cargo manifest file
         path = os.path.relpath(path)
-        # file = sys._getframe(1).f_globals.get('__file__')
-        # if file:
-        #     dirname = os.path.dirname(file)
-        #     print(dirname)
-        #     if dirname:
-        #         cwd = os.getcwd()
-        #         os.chdir(dirname)
-        #         path = os.path.abspath(path)
-        #         os.chdir(cwd)
-
         self.path = path
 
     def get_lib_name(self):
@@ -158,8 +147,7 @@ class RustExtension:
                 f.write(TMPL.format({"name": name}))
 
 
-TMPL = """from __future__ import absolute_import, print_function
-
+TMPL = """
 import os
 import sys
 
@@ -171,5 +159,5 @@ def run():
     if os.path.isfile(file):
         os.execv(file, sys.argv)
     else:
-        print("Can not execute '%s'" % name)
+        print("can't execute '{name}'")
 """

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -1,6 +1,9 @@
+from abc import ABC, abstractmethod
 from distutils import log
+from distutils.cmd import Command
 from distutils.command.check import check
 from distutils.command.clean import clean
+from distutils.errors import DistutilsPlatformError
 from setuptools.command.install import install
 from setuptools.command.build_ext import build_ext
 
@@ -8,6 +11,9 @@ try:
     from wheel.bdist_wheel import bdist_wheel
 except ImportError:
     bdist_wheel = None
+
+from .extension import RustExtension
+from .utils import get_rust_version
 
 
 def add_rust_extension(dist):

--- a/setuptools_rust/test.py
+++ b/setuptools_rust/test.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import
 import os
 import sys
 import subprocess
@@ -8,40 +7,19 @@ from distutils.errors import CompileError, DistutilsFileError, DistutilsExecErro
 import semantic_version
 
 from .extension import RustExtension
-from .utils import cpython_feature, get_rust_version
+from .utils import rust_features, get_rust_version
 
 MIN_VERSION = semantic_version.Spec(">=1.15")
 
 
 class test_rust(Command):
-    """ Run cargo test"""
+    """Run cargo test"""
 
-    description = "test rust extensions"
+    description = "test Rust extensions"
 
     user_options = []
 
-    def initialize_options(self):
-        self.extensions = ()
-
-    def finalize_options(self):
-        self.extensions = [
-            ext
-            for ext in self.distribution.rust_extensions
-            if isinstance(ext, RustExtension)
-        ]
-
-    def run(self):
-        if not self.extensions:
-            return
-
-        version = get_rust_version()
-        if version not in MIN_VERSION:
-            print(
-                "Rust version mismatch: required rust%s got rust%s"
-                % (MIN_VERSION, version)
-            )
-            return
-
+    def run_for_extension(self, ext: RustExtension):
         # Make sure that if pythonXX-sys is used, it builds against the current
         # executing python interpreter.
         bindir = os.path.dirname(sys.executable)
@@ -57,37 +35,36 @@ class test_rust(Command):
             }
         )
 
-        for ext in self.extensions:
-            if not os.path.exists(ext.path):
-                raise DistutilsFileError(
-                    "Can not file rust extension project file: %s" % ext.path
-                )
-
-            features = set(ext.features)
-            features.update(cpython_feature(ext=False, binding=ext.binding))
-
-            # test cargo command
-            feature_args = ["--features", " ".join(features)] if features else []
-            args = (
-                ["cargo", "test", "--manifest-path", ext.path]
-                + feature_args
-                + list(ext.args or [])
+        if not os.path.exists(ext.path):
+            raise DistutilsFileError(
+                f"can't find Rust extension project file: {ext.path}"
             )
 
-            # Execute cargo command
-            print(" ".join(args))
-            try:
-                subprocess.check_output(args, env=env)
-            except subprocess.CalledProcessError as e:
-                raise CompileError(
-                    "cargo failed with code: %d\n%s"
-                    % (e.returncode, e.output.decode("utf-8"))
-                )
-            except OSError:
-                raise DistutilsExecError(
-                    "Unable to execute 'cargo' - this package "
-                    "requires rust to be installed and "
-                    "cargo to be on the PATH"
-                )
-            else:
-                print("Test has been completed for '%s' extension" % ext.name)
+        features = set(ext.features)
+        features.update(rust_features(ext=False, binding=ext.binding))
+
+        # test cargo command
+        feature_args = ["--features", " ".join(features)] if features else []
+        args = (
+            ["cargo", "test", "--manifest-path", ext.path]
+            + feature_args
+            + list(ext.args or [])
+        )
+
+        # Execute cargo command
+        print(" ".join(args))
+        try:
+            subprocess.check_output(args, env=env)
+        except subprocess.CalledProcessError as e:
+            raise CompileError(
+                "cargo failed with code: %d\n%s"
+                % (e.returncode, e.output.decode("utf-8"))
+            )
+        except OSError:
+            raise DistutilsExecError(
+                "Unable to execute 'cargo' - this package "
+                "requires Rust to be installed and "
+                "cargo to be on the PATH"
+            )
+        else:
+            print(f"test completed for '{ext.name}' extension")

--- a/setuptools_rust/tomlgen.py
+++ b/setuptools_rust/tomlgen.py
@@ -1,12 +1,7 @@
 # coding: utf-8
-import glob
+import configparser
 import os
 import string
-
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
 
 import setuptools
 
@@ -21,7 +16,7 @@ __all__ = ["tomlgen"]
 
 class tomlgen_rust(setuptools.Command):
 
-    description = "Generate `Cargo.toml` for rust extensions"
+    description = "Generate `Cargo.toml` for Rust extensions"
 
     user_options = [
         (str("force"), str("f"), str("overwrite existing files if any")),

--- a/setuptools_rust/utils.py
+++ b/setuptools_rust/utils.py
@@ -1,12 +1,12 @@
-from __future__ import print_function, absolute_import
 import sys
 import subprocess
+from enum import IntEnum
 from distutils.errors import DistutilsPlatformError
 
 import semantic_version
 
 
-class Binding:
+class Binding(IntEnum):
     """
     Binding Options
     """
@@ -20,7 +20,7 @@ class Binding:
     Exec = 3
 
 
-class Strip:
+class Strip(IntEnum):
     """
     Strip Options
     """
@@ -32,19 +32,19 @@ class Strip:
     All = 2
 
 
-def cpython_feature(ext=True, binding=Binding.PyO3):
+def rust_features(ext=True, binding=Binding.PyO3):
     version = sys.version_info
 
     if binding in (Binding.NoBinding, Binding.Exec):
         return ()
     elif binding is Binding.PyO3:
-        if version > (3, 5):
+        if version >= (3, 6):
             if ext:
                 return {"pyo3/extension-module"}
             else:
                 return {}
         else:
-            raise DistutilsPlatformError("Unsupported python version: %s" % sys.version)
+            raise DistutilsPlatformError(f"unsupported python version: {sys.version}")
     elif binding is Binding.RustCPython:
         if (3, 3) < version:
             if ext:
@@ -52,21 +52,19 @@ def cpython_feature(ext=True, binding=Binding.PyO3):
             else:
                 return {"cpython/python3-sys"}
         else:
-            raise DistutilsPlatformError("Unsupported python version: %s" % sys.version)
+            raise DistutilsPlatformError(f"unsupported python version: {sys.version}")
     else:
-        raise DistutilsPlatformError('Unknown Binding: "{}" '.format(binding))
+        raise DistutilsPlatformError(f"unknown Rust binding: '{binding}'")
 
 
 def get_rust_version():
     try:
-        output = subprocess.check_output(["rustc", "-V"])
-        if isinstance(output, bytes):
-            output = output.decode("latin-1")
+        output = subprocess.check_output(["rustc", "-V"]).decode("latin-1")
         return semantic_version.Version(output.split(" ")[1], partial=True)
     except (subprocess.CalledProcessError, OSError):
-        raise DistutilsPlatformError("Can not find Rust compiler")
+        raise DistutilsPlatformError("can't find Rust compiler")
     except Exception as exc:
-        raise DistutilsPlatformError("Can not get rustc version: %s" % str(exc))
+        raise DistutilsPlatformError(f"can't get rustc version: {str(exc)}")
 
 
 def get_rust_target_info():


### PR DESCRIPTION
This PR tries to re-use more of the library logic into repeatable patterns. I also bumped the minimum Python version to 3.6, made liberal use of f-strings, and changed many error messages to start with lowercase.

@tiran would you be willing to pass a quick review over this? In particular the new `RustCommand` base class should ensure that optional extensions failing will always print a nice message (thanks to `except Exception` on line 45 of `command.py`). 

Fixes #105
