### PR TITLE
doc: improve error message for missing Rust compiler

### DIFF
--- a/setuptools_rust/command.py
+++ b/setuptools_rust/command.py
@@ -25,7 +25,15 @@ class RustCommand(Command, ABC):
 
         all_optional = all(ext.optional for ext in self.extensions)
         try:
-            version = get_rust_version()
+            version = get_rust_version(
+                min_version=max(
+                    filter(
+                        lambda version: version is not None,
+                        (ext.get_rust_version() for ext in self.extensions),
+                    ),
+                    default=None
+                )
+            )
         except DistutilsPlatformError as e:
             if not all_optional:
                 raise

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -123,7 +123,7 @@ class RustExtension:
         if self.rust_version is None:
             return None
         try:
-            return semantic_version.Spec(self.rust_version)
+            return semantic_version.SimpleSpec.parse(self.rust_version)
         except ValueError:
             raise DistutilsSetupError(
                 "Can not parse rust compiler version: %s", self.rust_version

--- a/setuptools_rust/utils.py
+++ b/setuptools_rust/utils.py
@@ -57,12 +57,32 @@ def rust_features(ext=True, binding=Binding.PyO3):
         raise DistutilsPlatformError(f"unknown Rust binding: '{binding}'")
 
 
-def get_rust_version():
+def get_rust_version(min_version=None):
     try:
         output = subprocess.check_output(["rustc", "-V"]).decode("latin-1")
         return semantic_version.Version(output.split(" ")[1], partial=True)
     except (subprocess.CalledProcessError, OSError):
-        raise DistutilsPlatformError("can't find Rust compiler")
+        raise DistutilsPlatformError(
+            "can't find Rust compiler\n\n"
+            "If you are using an outdated pip version, it is possible a "
+            "prebuilt wheel is available for this package but pip is not able "
+            "to install from it. Installing from the wheel would avoid the "
+            "need for a Rust compiler.\n\n"
+            "To update pip, run:\n\n"
+            "    pip install --upgrade pip\n\n"
+            "and then retry package installation.\n\n"
+            "If you did intend to build this package from source, try "
+            "installing a Rust compiler from your system package manager and "
+            "ensure it is on the PATH during installation. Alternatively, "
+            "rustup (available at https://rustup.rs) is the recommended way "
+            "to download and update the Rust compiler toolchain."
+            + (
+
+                f"\n\nThis package requires Rust {min_version}."
+                if min_version is not None
+                else ""
+            )
+        )
     except Exception as exc:
         raise DistutilsPlatformError(f"can't get rustc version: {str(exc)}")
 


### PR DESCRIPTION
This PR tries to help out with a more helpful error message for users who don't have a working Rust compiler, and may even not know they need one.

cc @alex  - I think this tries to capture the common cases you've experienced in cryptography. I'd appreciate any feedback you have on whether you think this error message is helpful, too long, suggested wording changes, or any other thoughts you have on it.

Example output a cryptography user might see:

```
error: can't find Rust compiler

If you are using an outdated pip version or do not have `wheel` installed, it is possible a prebuilt wheel is available for
this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.

To update pip and wheel, run:

    pip install --upgrade pip wheel

and then retry package installation.

If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ens
ure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to
download and update the Rust compiler toolchain.

This package requires Rust >=1.41.0.
```