### PR TITLE
setup.cfg: fix classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Intended Audience :: Developers
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8


### PR DESCRIPTION
Support for Python 3.5 dropped, so remove corresponding classifier.