### PR TITLE
Add --target command line option for specify target triple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+### Added
+- Add `--target` command line option for specifying target triple. [#136](https://github.com/PyO3/setuptools-rust/pull/136)
+
 ### Removed
 - Remove `test_rust` command. (`python setup.py test` is deprecated.) [#129](https://github.com/PyO3/setuptools-rust/pull/129)
 - Remove `check_rust` command. [#131](https://github.com/PyO3/setuptools-rust/pull/131)

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -49,7 +49,7 @@ class build_rust(RustCommand):
         self.qbuild = None
         self.build_temp = None
         self.plat_name = None
-        self.target = None
+        self.target = os.getenv("CARGO_BUILD_TARGET")
 
     def finalize_options(self):
         super().finalize_options()
@@ -67,9 +67,7 @@ class build_rust(RustCommand):
         # we'll target a 32-bit Rust build.
         # Automatic target detection can be overridden via the CARGO_BUILD_TARGET
         # environment variable or --target command line option
-        if os.getenv("CARGO_BUILD_TARGET"):
-            return os.environ["CARGO_BUILD_TARGET"]
-        elif self.target:
+        if self.target:
             return self.target
         elif self.plat_name == "win32":
             return "i686-pc-windows-msvc"

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -37,6 +37,7 @@ class build_rust(RustCommand):
             "t",
             "directory for temporary files (cargo 'target' directory) ",
         ),
+        ("target", None, "Build for the target triple"),
     ]
     boolean_options = ["inplace", "debug", "release", "qbuild"]
 
@@ -48,6 +49,7 @@ class build_rust(RustCommand):
         self.qbuild = None
         self.build_temp = None
         self.plat_name = None
+        self.target = None
 
     def finalize_options(self):
         super().finalize_options()
@@ -64,9 +66,11 @@ class build_rust(RustCommand):
         # If we are on a 64-bit machine, but running a 32-bit Python, then
         # we'll target a 32-bit Rust build.
         # Automatic target detection can be overridden via the CARGO_BUILD_TARGET
-        # environment variable.
+        # environment variable or --target command line option
         if os.getenv("CARGO_BUILD_TARGET"):
             return os.environ["CARGO_BUILD_TARGET"]
+        elif self.target:
+            return self.target
         elif self.plat_name == "win32":
             return "i686-pc-windows-msvc"
         elif self.plat_name == "win-amd64":

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -99,7 +99,7 @@ def add_rust_extension(dist):
 
         def initialize_options(self):
             super().initialize_options()
-            self.target = None
+            self.target = os.getenv("CARGO_BUILD_TARGET")
 
         def run(self):
             if self.distribution.rust_extensions:
@@ -174,7 +174,7 @@ def add_rust_extension(dist):
 
             def initialize_options(self):
                 super().initialize_options()
-                self.target = None
+                self.target = os.getenv("CARGO_BUILD_TARGET")
 
             def finalize_options(self):
                 scripts = []

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -91,14 +91,23 @@ def add_rust_extension(dist):
     dist.cmdclass["sdist"] = sdist_rust_extension
 
     build_ext_base_class = dist.cmdclass.get('build_ext', build_ext)
+    build_ext_options = build_ext_base_class.user_options.copy()
+    build_ext_options.append(("target", None, "Build for the target triple"))
 
     class build_ext_rust_extension(build_ext_base_class):
+        user_options = build_ext_options
+
+        def initialize_options(self):
+            super().initialize_options()
+            self.target = None
+
         def run(self):
             if self.distribution.rust_extensions:
                 log.info("running build_rust")
                 build_rust = self.get_finalized_command("build_rust")
                 build_rust.inplace = self.inplace
                 build_rust.plat_name = self.plat_name
+                build_rust.target = self.target
                 build_rust.run()
 
             build_ext_base_class.run(self)
@@ -156,9 +165,17 @@ def add_rust_extension(dist):
 
     if bdist_wheel is not None:
         bdist_wheel_base_class = dist.cmdclass.get("bdist_wheel", bdist_wheel)
+        bdist_wheel_options = bdist_wheel_base_class.user_options.copy()
+        bdist_wheel_options.append(("target", None, "Build for the target triple"))
 
         # this is for console entries
         class bdist_wheel_rust_extension(bdist_wheel_base_class):
+            user_options = bdist_wheel_options
+
+            def initialize_options(self):
+                super().initialize_options()
+                self.target = None
+
             def finalize_options(self):
                 scripts = []
                 for ext in self.distribution.rust_extensions:


### PR DESCRIPTION
This mimics the same `--target` option of cargo and maturin, it's much more discoverable than the `CARGO_BUILD_TARGET` environment variable IMO.