### PR TITLE
Generate correct tag for universal wheels

### DIFF
--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -215,6 +215,9 @@ def add_rust_extension(dist):
                         self.bdist_dir,
                         "macosx-{}-universal2".format(macos_target)
                     )
+
+                if self.universal:
+                    return "py3", "none", plat
                 return python, abi, plat
         dist.cmdclass["bdist_wheel"] = bdist_wheel_rust_extension
 


### PR DESCRIPTION
Hi!

I'm [moving a Python package](https://github.com/dib-lab/sourmash/pull/1564) from using milksnake to setuptools-rust, since it is more active and it supports `universal2` wheels on macOS. It mostly worked, but I hit a problem related to how milksnake supports [Python's universal wheels](https://github.com/getsentry/milksnake#what-is-supported) (without dependency on the CPython API at all, because `cffi` does all the work). That's how I've been generating wheels and [distributing them at PyPI](https://pypi.org/project/sourmash/4.1.1/#files), but when I generate wheels with `setuptools-rust` it comes out with a `cp38-cp38-linux_x86_64` tag (or `cp38-abi3-linux_x86_64` if using `python setup.py bdist_wheel --py-limited-api=cp38`)

This PR does something similar to what [`milksnake` does](https://github.com/getsentry/milksnake/blob/ef0723e41df23d8f6357570c69c1e69cb31f9e9e/milksnake/setuptools_ext.py#L312L317), but it feels a bit of a hack (especially since there seems to be [some pushback](https://github.com/pypa/setuptools/issues/1976) with universal wheels in general, now that Python 2 is no more).

Is this a change that looks acceptable, or should I look for other approaches to fix my problem?

Thanks!