### PR TITLE
Patch distutils build command to use `has_ext_modules()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Use info from sysconfig when cross-compiling. [#139](https://github.com/PyO3/setuptools-rust/pull/139)
+- Put Rust extension module binary under `build/lib.*` directory. [#150](https://github.com/PyO3/setuptools-rust/pull/150)
 
 ## 0.12.1 (2021-03-11)
 ### Fixed


### PR DESCRIPTION
Fixes #146 

Upstream patch: https://github.com/pypa/distutils/pull/43