### PR TITLE
Replace semantic_version with packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Put Rust extension module binary under `build/lib.*` directory. [#150](https://github.com/PyO3/setuptools-rust/pull/150)
 - Fix `Exec` binding with console scripts. [#154](https://github.com/PyO3/setuptools-rust/pull/154)
 
+### Changed
+- Replace `semantic_version` with `packaging` to parse version specs. [#157](https://github.com/PyO3/setuptools-rust/pull/157)
+
 ## 0.12.1 (2021-03-11)
 ### Fixed
 - Fix some files unexpectedly missing from `sdist` command output. [#125](https://github.com/PyO3/setuptools-rust/pull/125)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 [options]
 packages = setuptools_rust
 zip_safe = True
-install_requires = setuptools>=46.1; semantic_version>=2.6.0; toml>=0.9.0; typing_extensions>=3.7.4.3
+install_requires = setuptools>=46.1; packaging; toml>=0.9.0; typing_extensions>=3.7.4.3
 setup_requires = setuptools>=46.1; setuptools_scm[toml]>=3.4.3
 python_requires = >=3.6
 

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -5,7 +5,7 @@ from enum import IntEnum, auto
 from typing import Dict, List, Optional, Union
 from typing_extensions import Literal
 
-import semantic_version
+from packaging.specifiers import SpecifierSet
 
 
 class Binding(IntEnum):
@@ -165,7 +165,7 @@ class RustExtension:
         if self.rust_version is None:
             return None
         try:
-            return semantic_version.SimpleSpec.parse(self.rust_version)
+            return SpecifierSet(self.rust_version)
         except ValueError:
             raise DistutilsSetupError(
                 "Can not parse rust compiler version: %s", self.rust_version

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -164,8 +164,12 @@ class RustExtension:
     def get_rust_version(self):
         if self.rust_version is None:
             return None
+        # map nightly suffix to PEP 440-compatible .dev0 suffix
+        rust_version = self.rust_version
+        if rust_version.endswith("-nightly"):
+            rust_version = rust_version[:-8] + ".dev0"
         try:
-            return SpecifierSet(self.rust_version)
+            return SpecifierSet(rust_version)
         except ValueError:
             raise DistutilsSetupError(
                 "Can not parse rust compiler version: %s", self.rust_version

--- a/setuptools_rust/utils.py
+++ b/setuptools_rust/utils.py
@@ -2,7 +2,7 @@ import subprocess
 from distutils.errors import DistutilsPlatformError
 from typing import Set, Union
 
-import semantic_version
+from packaging.version import Version
 from typing_extensions import Literal
 
 from .extension import Binding, RustExtension
@@ -34,7 +34,7 @@ def binding_features(
 def get_rust_version(min_version=None):
     try:
         output = subprocess.check_output(["rustc", "-V"]).decode("latin-1")
-        return semantic_version.Version(output.split(" ")[1], partial=True)
+        return Version(output.split(" ")[1])
     except (subprocess.CalledProcessError, OSError):
         raise DistutilsPlatformError(
             "can't find Rust compiler\n\n"


### PR DESCRIPTION
Use the "packaging" package instead of semantic_version package to parse
Rust version and spec. Packaging is used by setuptools to parse version
strings and specs.

This also solves a deprecation warning with semamtic_version. The
partial argument to Version() has been deprecated.

Signed-off-by: Christian Heimes <christian@python.org>