### PR TITLE
examples: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+
+  - package-ecosystem: "cargo"
+    directory: "examples/hello-world"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "cargo"
+    directory: "examples/html-py-ever"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "cargo"
+    directory: "examples/namespace_package"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "cargo"
+    directory: "examples/rust_with_cffi"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Closes #124 

I'd like to keep a specific PyO3 version instead of a "*" because I think it's good practice for users to use specific versions in `Cargo.toml` files. Therefore it makes sense to use specific versions in our examples.

At least here this'll add a dependabot config so we keep the examples up-to-date.