### PR TITLE
deps: update versions; switch to tomli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Add new default `"auto"` setting for `RustExtension.py_limited_api`. [#137](https://github.com/PyO3/setuptools-rust/pull/137)
 - Support very verbose cargo build.rs output. [#140](https://github.com/PyO3/setuptools-rust/pull/140)
 
+### Changed
+- Switch to `tomli` dependency. [#174](https://github.com/PyO3/setuptools-rust/pull/174)
+
 ### Removed
 - Remove `test_rust` command. (`python setup.py test` is deprecated.) [#129](https://github.com/PyO3/setuptools-rust/pull/129)
 - Remove `check_rust` command. [#131](https://github.com/PyO3/setuptools-rust/pull/131)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ classifiers =
 [options]
 packages = setuptools_rust
 zip_safe = True
-install_requires = setuptools>=46.1; semantic_version>=2.6.0; toml>=0.9.0; typing_extensions>=3.7.4.3
-setup_requires = setuptools>=46.1; setuptools_scm[toml]>=3.4.3
+install_requires = setuptools>=46.1; semantic_version>=2.6.0; tomli>=1.2.1; typing_extensions>=3.7.4.3
+setup_requires = setuptools>=46.1; setuptools_scm>=6.3.2
 python_requires = >=3.6
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 [options]
 packages = setuptools_rust
 zip_safe = True
-install_requires = setuptools>=46.1; semantic_version>=2.6.0; tomli>=1.2.1; typing_extensions>=3.7.4.3
+install_requires = setuptools>=46.1; semantic_version>=2.8.2,<3; tomli>=1.2.1; typing_extensions>=3.7.4.3
 setup_requires = setuptools>=46.1; setuptools_scm>=6.3.2
 python_requires = >=3.6
 

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -4,8 +4,8 @@ from distutils.errors import DistutilsSetupError
 from enum import IntEnum, auto
 from typing import Dict, List, Optional, Union
 
-import semantic_version
 import tomli
+from semantic_version import SimpleSpec
 from typing_extensions import Literal
 
 
@@ -160,11 +160,11 @@ class RustExtension:
         name = re.sub(r"[./\\-]", "_", name)
         return name
 
-    def get_rust_version(self):
+    def get_rust_version(self) -> Optional[SimpleSpec]:
         if self.rust_version is None:
             return None
         try:
-            return semantic_version.SimpleSpec.parse(self.rust_version)
+            return SimpleSpec(self.rust_version)
         except ValueError:
             raise DistutilsSetupError(
                 "Can not parse rust compiler version: %s", self.rust_version

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -5,6 +5,7 @@ from enum import IntEnum, auto
 from typing import Dict, List, Optional, Union
 
 import semantic_version
+import tomli
 from typing_extensions import Literal
 
 
@@ -145,10 +146,8 @@ class RustExtension:
 
     def get_lib_name(self):
         """Parse Cargo.toml to get the name of the shared library."""
-        # We import in here to make sure the the setup_requires are already installed
-        import toml
-
-        cfg = toml.load(self.path)
+        with open(self.path, "rb") as f:
+            cfg = tomli.load(f)
         name = cfg.get("lib", {}).get("name")
         if name is None:
             name = cfg.get("package", {}).get("name")

--- a/setuptools_rust/utils.py
+++ b/setuptools_rust/utils.py
@@ -1,8 +1,8 @@
 import subprocess
 from distutils.errors import DistutilsPlatformError
-from typing import Set, Union
+from typing import Optional, Set, Union
 
-import semantic_version
+from semantic_version import Version
 from typing_extensions import Literal
 
 from .extension import Binding, RustExtension
@@ -31,33 +31,12 @@ def binding_features(
         raise DistutilsPlatformError(f"unknown Rust binding: '{ext.binding}'")
 
 
-def get_rust_version(min_version=None):
+def get_rust_version() -> Optional[Version]:
     try:
         output = subprocess.check_output(["rustc", "-V"]).decode("latin-1")
-        return semantic_version.Version(output.split(" ")[1], partial=True)
+        return Version(output.split(" ")[1])
     except (subprocess.CalledProcessError, OSError):
-        raise DistutilsPlatformError(
-            "can't find Rust compiler\n\n"
-            "If you are using an outdated pip version, it is possible a "
-            "prebuilt wheel is available for this package but pip is not able "
-            "to install from it. Installing from the wheel would avoid the "
-            "need for a Rust compiler.\n\n"
-            "To update pip, run:\n\n"
-            "    pip install --upgrade pip\n\n"
-            "and then retry package installation.\n\n"
-            "If you did intend to build this package from source, try "
-            "installing a Rust compiler from your system package manager and "
-            "ensure it is on the PATH during installation. Alternatively, "
-            "rustup (available at https://rustup.rs) is the recommended way "
-            "to download and update the Rust compiler toolchain."
-            + (
-                f"\n\nThis package requires Rust {min_version}."
-                if min_version is not None
-                else ""
-            )
-        )
-    except Exception as exc:
-        raise DistutilsPlatformError(f"can't get rustc version: {str(exc)}")
+        return None
 
 
 def get_rust_target_info(target_triple=None):


### PR DESCRIPTION
Also removes use of deprecated `partial` option to `semantic_version.Version`.