### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.0.0 (2021-11-21)
 ### Added
 - Add `--target` command line option for specifying target triple. [#136](https://github.com/PyO3/setuptools-rust/pull/136)
 - Add new default `"auto"` setting for `RustExtension.py_limited_api`. [#137](https://github.com/PyO3/setuptools-rust/pull/137)


### PR DESCRIPTION
This PR bumps the version to 1.0.0, which I think we're now ready to release!

I think the main functionality of `setuptools_rust` to build rust extension has been stable for a long time, and additionally I don't expect we will need to change it for now. So I suggest we are ready to release 1.0.

There are a couple of nice-to-haves prehaps still missing like cross-compiling with `cross` (#10 / #134). We can always add those later.

If I don't hear a reason not to do this, I'll put it live weekend after next.

Closes #132 