### PR TITLE
exec: fix for windows

### DIFF
--- a/examples/hello-world/setup.py
+++ b/examples/hello-world/setup.py
@@ -1,11 +1,16 @@
 from setuptools import setup
+
 from setuptools_rust import Binding, RustExtension
 
 setup(
     name="hello-world",
     version="1.0",
     rust_extensions=[
-        RustExtension("hello_world.hello_world", binding=Binding.Exec, script=True)
+        RustExtension(
+            {"hello-world": "hello_world.hello_world"},
+            binding=Binding.Exec,
+            script=True,
+        )
     ],
     # rust extensions are not zip safe, just like C-extensions.
     zip_safe=False,

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -180,25 +180,23 @@ class RustExtension:
 
         return entry_points
 
-    def install_script(self, ext_path):
+    def install_script(self, module_name: str, exe_path: str):
         if self.script and self.binding == Binding.Exec:
-            dirname, name = os.path.split(ext_path)
-            file = os.path.join(dirname, "_gen_%s.py" % name)
+            dirname, executable = os.path.split(exe_path)
+            file = os.path.join(dirname, "_gen_%s.py" % module_name)
             with open(file, "w") as f:
-                f.write(TMPL.format(name=name))
+                f.write(TMPL.format(executable=repr(executable)))
 
 
 TMPL = """
 import os
 import sys
 
-
 def run():
     path = os.path.split(__file__)[0]
-    name = os.path.split(sys.argv[0])[1]
-    file = os.path.join(path, name)
+    file = os.path.join(path, {executable})
     if os.path.isfile(file):
         os.execv(file, sys.argv)
     else:
-        print("can't execute '{name}'")
+        raise RuntimeError("can't find " + file)
 """


### PR DESCRIPTION
Closes #179 

This uses `sysconfig.get_config_var("EXE")` to correctly find the correct file to copy.

After #154 I think the windows CI for `hello_world` example was incorrectly passing because the launcher script would just run `print("can't execute '{name}'")` and exit successfully. With this patch the CI now passes properly.