### PR TITLE
python: fix support for 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Fix incompatibility with Python 3.6.0 using default values for NamedTuple classes. [#184](https://github.com/PyO3/setuptools-rust/pull/184)
+
 ## 1.0.0 (2021-11-21)
 ### Added
 - Add `--target` command line option for specifying target triple. [#136](https://github.com/PyO3/setuptools-rust/pull/136)


### PR DESCRIPTION
Closes #183 

Also fixes a couple of other mypy warnings at the same time (mostly by adding asserts).