### PR TITLE
ci: add mypy typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,20 @@ jobs:
 
       - run: black --check .
 
+  mypy:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - run: pip install tox
+
+      - run: tox -e mypy
+
   build:
     name:  ${{ matrix.python-version }} ${{ matrix.platform.os }}-${{ matrix.platform.python-architecture }}
     runs-on: ${{ matrix.platform.os }}

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,19 @@
+# We have to manually ignore types for some packages. It would be great if
+# interested users want to add these types to typeshed!
+
+[mypy]
+show_error_codes = True
+
+disallow_untyped_defs = True
+disallow_any_unimported = True
+no_implicit_optional = True
+check_untyped_defs = True
+
+warn_return_any = True
+warn_unused_ignores = True
+
+[mypy-semantic_version.*]
+ignore_missing_imports = True
+
+[mypy-wheel.*]
+ignore_missing_imports = True

--- a/setuptools_rust/clean.py
+++ b/setuptools_rust/clean.py
@@ -1,5 +1,5 @@
-import sys
 import subprocess
+import sys
 
 from .command import RustCommand
 from .extension import RustExtension
@@ -10,11 +10,11 @@ class clean_rust(RustCommand):
 
     description = "clean Rust extensions (compile/link to build directory)"
 
-    def initialize_options(self):
+    def initialize_options(self) -> None:
         super().initialize_options()
         self.inplace = False
 
-    def run_for_extension(self, ext: RustExtension):
+    def run_for_extension(self, ext: RustExtension) -> None:
         # build cargo command
         args = ["cargo", "clean", "--manifest-path", ext.path]
 

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -27,7 +27,7 @@ class Binding(IntEnum):
     NoBinding = auto()
     Exec = auto()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}.{self.name}"
 
 
@@ -45,7 +45,7 @@ class Strip(IntEnum):
     Debug = auto()
     All = auto()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}.{self.name}"
 
 
@@ -144,7 +144,7 @@ class RustExtension:
         path = os.path.relpath(path)
         self.path = path
 
-    def get_lib_name(self):
+    def get_lib_name(self) -> str:
         """Parse Cargo.toml to get the name of the shared library."""
         with open(self.path, "rb") as f:
             cfg = tomli.load(f)
@@ -157,10 +157,14 @@ class RustExtension:
                 "Cargo.toml missing value for 'name' key "
                 "in both the [package] section and the [lib] section"
             )
+        if not isinstance(name, str):
+            raise Exception(
+                f"Expected string for Rust library name in Cargo.toml, got {name}"
+            )
         name = re.sub(r"[./\\-]", "_", name)
         return name
 
-    def get_rust_version(self) -> Optional[SimpleSpec]:
+    def get_rust_version(self) -> Optional[SimpleSpec]:  # type: ignore[no-any-unimported]
         if self.rust_version is None:
             return None
         try:
@@ -170,7 +174,7 @@ class RustExtension:
                 "Can not parse rust compiler version: %s", self.rust_version
             )
 
-    def entry_points(self):
+    def entry_points(self) -> List[str]:
         entry_points = []
         if self.script and self.binding == Binding.Exec:
             for name, mod in self.target.items():
@@ -180,7 +184,7 @@ class RustExtension:
 
         return entry_points
 
-    def install_script(self, module_name: str, exe_path: str):
+    def install_script(self, module_name: str, exe_path: str) -> None:
         if self.script and self.binding == Binding.Exec:
             dirname, executable = os.path.split(exe_path)
             file = os.path.join(dirname, "_gen_%s.py" % module_name)

--- a/setuptools_rust/utils.py
+++ b/setuptools_rust/utils.py
@@ -1,13 +1,13 @@
 import subprocess
 from distutils.errors import DistutilsPlatformError
-from typing import Optional, Set, Union
+from typing import List, Optional, Set, Union
 
 from semantic_version import Version
 from typing_extensions import Literal
 
 from .extension import Binding, RustExtension
 
-PyLimitedApi = Union[Literal["cp36", "cp37", "cp38", "cp39"], bool]
+PyLimitedApi = Literal["cp36", "cp37", "cp38", "cp39", True, False]
 
 
 def binding_features(
@@ -31,7 +31,7 @@ def binding_features(
         raise DistutilsPlatformError(f"unknown Rust binding: '{ext.binding}'")
 
 
-def get_rust_version() -> Optional[Version]:
+def get_rust_version() -> Optional[Version]:  # type: ignore[no-any-unimported]
     try:
         output = subprocess.check_output(["rustc", "-V"]).decode("latin-1")
         return Version(output.split(" ")[1])
@@ -39,18 +39,18 @@ def get_rust_version() -> Optional[Version]:
         return None
 
 
-def get_rust_target_info(target_triple=None):
+def get_rust_target_info(target_triple: Optional[str] = None) -> List[str]:
     cmd = ["rustc", "--print", "cfg"]
     if target_triple:
         cmd.extend(["--target", target_triple])
-    output = subprocess.check_output(cmd)
+    output = subprocess.check_output(cmd, universal_newlines=True)
     return output.splitlines()
 
 
 _rust_target_list = None
 
 
-def get_rust_target_list():
+def get_rust_target_list() -> List[str]:
     global _rust_target_list
     if _rust_target_list is None:
         output = subprocess.check_output(

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = mypy
+
+[testenv:mypy]
+deps =
+    # Need next mypy after 0.910 to get correct types for distutils,
+    # but it's not released yet.
+    mypy @ git+https://github.com/python/mypy
+    fat_macho
+    types-setuptools
+setenv =
+    MYPYPATH={toxinidir}
+commands = mypy setuptools_rust {posargs}


### PR DESCRIPTION
Adds a full mypy job to CI.

There's a fair few uses of `# type: ignore` which I think are inevitable without help getting upstream types improved. This will do for now. There's also one `FIXME` for an internal typing which I'll follow up with on #185 