### PR TITLE
windows: don't force msvc toolchain if using gnu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Fix incompatibility with Python 3.6.0 using default values for NamedTuple classes. [#184](https://github.com/PyO3/setuptools-rust/pull/184)
+- Stop forcing the `msvc` Rust toolchain for Windows environments using the `gnu` toolchain. [#187](https://github.com/PyO3/setuptools-rust/pull/187)
 
 ## 1.0.0 (2021-11-21)
 ### Added


### PR DESCRIPTION
Similar to #147; I've come across some situations in private codebases using the windows `gnu` toolchain where it would be helpful if setuptools-rust didn't automatically force `msvc` toolchain for these codebases.