### PR TITLE
readme: add quick note on cross compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Finished processing dependencies for hello_rust==1.0
 
 Or you can use commands like `bdist_wheel` (after installing `wheel`). See also [the notes in the documentation about building wheels](https://setuptools-rust.readthedocs.io/en/latest/building_wheels.html).
 
+Cross-compiling is also supported, using either [`crossenv`](https://github.com/benfogle/crossenv) or [`cross`](https://github.com/rust-embedded/cross). For examples see the `test-cross-compile` and `test-cross` Github actions jobs in [`ci.yml`](https://github.com/PyO3/setuptools-rust/blob/main/.github/workflows/ci.yml).
+
 By default, `develop` will create a debug build, while `install` will create a release build.
 
 ## Commands


### PR DESCRIPTION
Just a quick note to help users discover setuptools-rust's cross-compiling support.

I don't have time to write anything longer right now, future PRs welcome if anyone wants to add a separate page to the docs!