### PR TITLE
release: 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## Unreleased
-
+## 1.1.0 (2021-11-30)
 ### Added
 - Add support for cross-compiling using [`cross`](https://github.com/rust-embedded/cross). [#185](https://github.com/PyO3/setuptools-rust/pull/185)
 


### PR DESCRIPTION
This release includes the new support for `cross` along with the couple of bugfixes since 1.0. So I think a minor version bump to 1.1 is appropriate.

I'll plan to put this live tomorrow morning.