### PR TITLE
macos: don't try to configure cross-compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Fix regression from `setuptools-rust` 1.1.0 which broke builds for the `x86_64-unknown-linux-musl` target. [#194](https://github.com/PyO3/setuptools-rust/pull/194)
 - Fix `--target` command line option being unable to take a value. [#195](https://github.com/PyO3/setuptools-rust/pull/195)
+- Fix regression from `setuptools-rust` 1.0.0 which broke builds on arm64 macos conda builds. [#196](https://github.com/PyO3/setuptools-rust/pull/196)
 
 ## 1.1.0 (2021-11-30)
 ### Added

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -589,6 +589,12 @@ def _detect_unix_cross_compile_info() -> Optional["_CrossCompileInfo"]:
         # not *NIX, or not cross compiling
         return None
 
+    if "apple-darwin" in host_type and (build_type and "apple-darwin" in build_type):
+        # On macos and the build and host differ. This is probably an arm
+        # Python which was built on x86_64. Don't try to handle this for now.
+        # (See https://github.com/PyO3/setuptools-rust/issues/192)
+        return None
+
     stdlib = sysconfig.get_path("stdlib")
     assert stdlib is not None
     cross_lib = os.path.dirname(stdlib)


### PR DESCRIPTION
Just adds a workaround for #192.

Closes #192 