### PR TITLE
build: don't use abi3 lib suffix when py_limited_api unspecified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
 
       - run: tox -e mypy
 
+  pytest:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - run: pip install tox
+
+      - run: tox -e pytest
+
   build:
     name:  ${{ matrix.python-version }} ${{ matrix.platform.os }}-${{ matrix.platform.python-architecture }}
     runs-on: ${{ matrix.platform.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix regression from `setuptools-rust` 1.1.0 which broke builds for the `x86_64-unknown-linux-musl` target. [#194](https://github.com/PyO3/setuptools-rust/pull/194)
 - Fix `--target` command line option being unable to take a value. [#195](https://github.com/PyO3/setuptools-rust/pull/195)
 - Fix regression from `setuptools-rust` 1.0.0 which broke builds on arm64 macos conda builds. [#196](https://github.com/PyO3/setuptools-rust/pull/196)
+- Fix regression from `setuptools-rust` 1.1.0 which incorrectly converted library extension suffixes to the "abi3" suffix when `py_limited_api` was unspecified. [#197](https://github.com/PyO3/setuptools-rust/pull/197)
 
 ## 1.1.0 (2021-11-30)
 ### Added

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -113,7 +113,7 @@ class RustExtension:
         script: bool = False,
         native: bool = False,
         optional: bool = False,
-        py_limited_api: Union[bool, Literal["auto"]] = "auto",
+        py_limited_api: Literal["auto", True, False] = "auto",
     ):
         if isinstance(target, dict):
             name = "; ".join("%s=%s" % (key, val) for key, val in target.items())

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = mypy
+envlist = mypy,pytest
 
 [testenv:mypy]
 deps =
@@ -11,3 +11,8 @@ deps =
 setenv =
     MYPYPATH={toxinidir}
 commands = mypy setuptools_rust {posargs}
+
+[testenv:pytest]
+deps =
+    pytest
+commands = pytest --doctest-modules setuptools_rust {posargs}


### PR DESCRIPTION
Something I noticed when using 1.1.0 earlier. Basically with `py_limited_api="auto"` (the default), the abi3 lib name is used by default, which is not correct. The abi3 lib name should only be used with "auto" when `--py-limited-api` is passed to `setup.py bdist_wheel`.

Also added a quick `pytest` job with a unit test for this. Might be useful for later pieces.