### PR TITLE
release: 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.1.1 (2021-12-01)
 ### Fixed
 - Fix regression from `setuptools-rust` 1.1.0 which broke builds for the `x86_64-unknown-linux-musl` target. [#194](https://github.com/PyO3/setuptools-rust/pull/194)
 - Fix `--target` command line option being unable to take a value. [#195](https://github.com/PyO3/setuptools-rust/pull/195)


### PR DESCRIPTION
Contains a bunch of fixes from my usage of 1.1.0 as well as users' bug reports.

I'll put live in the morning if CI is green.