### PR TITLE
Remove the dependency on tomli to simplify installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.2 (UNRELEASED)
+### Changed
+- Removed dependency on `tomli` to simplify installation.
+
 ## 1.1.1 (2021-12-01)
 ### Fixed
 - Fix regression from `setuptools-rust` 1.1.0 which broke builds for the `x86_64-unknown-linux-musl` target. [#194](https://github.com/PyO3/setuptools-rust/pull/194)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 [options]
 packages = setuptools_rust
 zip_safe = True
-install_requires = setuptools>=46.1; semantic_version>=2.8.2,<3; tomli>=1.2.1; typing_extensions>=3.7.4.3
+install_requires = setuptools>=46.1; semantic_version>=2.8.2,<3; typing_extensions>=3.7.4.3
 setup_requires = setuptools>=46.1; setuptools_scm>=6.3.2
 python_requires = >=3.6
 


### PR DESCRIPTION
Depending on tomli produces circular dependencies when attempting to install from sdists only: https://github.com/pyca/cryptography/issues/6671