### PR TITLE
fix: improve handling of invalid rust_extensions values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.2 (UNRELEASED)
 ### Changed
 - Removed dependency on `tomli` to simplify installation.
+- Improve error messages on invalid inputs to `rust_extensions` keyword. [#203](https://github.com/PyO3/setuptools-rust/pull/203)
 
 ## 1.1.1 (2021-12-01)
 ### Fixed


### PR DESCRIPTION
In my own usage of `setuptools_rust` I have noticed a couple of unhelpful edge cases around how it treats the `rust_extensions` keyword. This PR tidies things up a bit.