### PR TITLE
exec: support kebab-case executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Added
+- Add support for `kebab-case` executable names. [#205](https://github.com/PyO3/setuptools-rust/pull/205)
+
 ## 1.1.2 (2021-12-05)
 ### Changed
 - Removed dependency on `tomli` to simplify installation. [#200](https://github.com/PyO3/setuptools-rust/pull/200)

--- a/examples/hello-world/setup.py
+++ b/examples/hello-world/setup.py
@@ -7,7 +7,7 @@ setup(
     version="1.0",
     rust_extensions=[
         RustExtension(
-            {"hello-world": "hello_world.hello_world"},
+            {"hello-world": "hello_world.hello-world"},
             binding=Binding.Exec,
             script=True,
         )

--- a/examples/hello-world/tox.ini
+++ b/examples/hello-world/tox.ini
@@ -6,5 +6,5 @@ requires =
 description = Run the unit tests under {basepython}
 deps =
     setuptools-rust @ file://{toxinidir}/../../
-commands = hello_world {posargs}
+commands = hello-world {posargs}
 passenv = *


### PR DESCRIPTION
Closes #191

Makes it possible to install executables with kebab-case names.