### PR TITLE
pytest: add options to `pyproject.toml`

### DIFF
--- a/examples/html-py-ever/tox.ini
+++ b/examples/html-py-ever/tox.ini
@@ -10,3 +10,7 @@ deps =
     beautifulsoup4
     pytest>=3.6
 commands = pytest {posargs}
+
+[pytest]
+testpaths =
+    test

--- a/examples/namespace_package/tox.ini
+++ b/examples/namespace_package/tox.ini
@@ -9,3 +9,7 @@ deps =
     pytest
 commands = pytest {posargs}
 passenv = *
+
+[pytest]
+testpaths =
+    tests

--- a/examples/rust_with_cffi/tox.ini
+++ b/examples/rust_with_cffi/tox.ini
@@ -9,3 +9,7 @@ deps =
     pytest
     cffi
 commands = pytest {posargs}
+
+[pytest]
+testpaths =
+    tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,7 @@ write_to = "setuptools_rust/version.py"
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--doctest-modules"

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ commands = mypy setuptools_rust {posargs}
 [testenv:pytest]
 deps =
     pytest
-commands = pytest --doctest-modules setuptools_rust {posargs}
+commands = pytest setuptools_rust {posargs}


### PR DESCRIPTION
cc @kloczek - will `pyproject.toml` be ok instead of `pytest.ini` ?