### PR TITLE
release: 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.2.0 (2022-03-22)
 ### Packaging
 - Drop support for Python 3.6. [#209](https://github.com/PyO3/setuptools-rust/pull/209)
 


### PR DESCRIPTION
I think we've accumulated enough changes to make worth releasing.

AFAIK it's fine in Python community to drop support for Python 3.6 in a minor release.