### PR TITLE
remove setuptools monkey patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
+### Packaging
+- Increase minimum `setuptools` version to 1.58. [#222](https://github.com/PyO3/setuptools-rust/pull/222)
+
 ### Fixed
-- Fix building sdist with vendored dependencies on Windows. [#223](https://github.com/PyO3/setuptools-rust/pull/223)
+- Fix crash when `python-distutils-extra` linux package is installed. [#222](https://github.com/PyO3/setuptools-rust/pull/222)
+- Fix sdist built with vendored dependencies on Windows having incorrect cargo config. [#223](https://github.com/PyO3/setuptools-rust/pull/223)
 
 ## 1.2.0 (2022-03-22)
 ### Packaging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=46.1", "setuptools_scm[toml]>=3.4.3"]
+requires = ["setuptools>=58.0", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
I believe the upstream PR in https://github.com/pypa/distutils/pull/43 got released in setuptools 58, so we can bump dependency and drop our patching.

@mgorny is there a way in which you can test if this fixes #221? My hunch is that it will.