### PR TITLE
feat: support cargo --locked flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Packaging
 - Increase minimum `setuptools` version to 62.4. [#222](https://github.com/PyO3/setuptools-rust/pull/246)
 
+### Added
+- Add `cargo_manifest_args` to support locked, frozen and offline builds. [#234](https://github.com/PyO3/setuptools-rust/pull/234)
+
 ### Fixed
 - If the sysconfig for `BLDSHARED` has no flags, `setuptools-rust` won't crash anymore. [#241](https://github.com/PyO3/setuptools-rust/pull/241)
 

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -46,6 +46,7 @@ class build_rust(RustCommand):
         ("debug", "d", "Force debug to true for all Rust extensions "),
         ("release", "r", "Force debug to false for all Rust extensions "),
         ("qbuild", None, "Force enable quiet option for all Rust extensions "),
+        ("locked", None, "Force enable locked option for all Rust extensions "),
         (
             "build-temp",
             "t",
@@ -63,6 +64,7 @@ class build_rust(RustCommand):
         self.debug = None
         self.release = None
         self.qbuild = None
+        self.locked = None
         self.build_temp = None
         self.plat_name = None
         self.target = os.getenv("CARGO_BUILD_TARGET")
@@ -145,9 +147,14 @@ class build_rust(RustCommand):
             target_dir = os.path.join(target_dir, target_triple)
 
         quiet = self.qbuild or ext.quiet
+        locked = self.locked or ext.locked
         debug = self._is_debug_build(ext)
         cargo_args = self._cargo_args(
-            ext=ext, target_triple=target_triple, release=not debug, quiet=quiet
+            ext=ext,
+            target_triple=target_triple,
+            release=not debug,
+            quiet=quiet,
+            locked=locked,
         )
 
         if ext._uses_exec_binding():
@@ -476,6 +483,7 @@ class build_rust(RustCommand):
         target_triple: Optional[str],
         release: bool,
         quiet: bool,
+        locked: bool,
     ) -> List[str]:
         args = []
         if target_triple is not None:
@@ -488,6 +496,9 @@ class build_rust(RustCommand):
 
         if quiet:
             args.append("-q")
+
+        if locked:
+            args.append("--locked")
 
         elif self.verbose:
             # cargo only have -vv

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -46,7 +46,6 @@ class build_rust(RustCommand):
         ("debug", "d", "Force debug to true for all Rust extensions "),
         ("release", "r", "Force debug to false for all Rust extensions "),
         ("qbuild", None, "Force enable quiet option for all Rust extensions "),
-        ("locked", None, "Force enable locked option for all Rust extensions "),
         (
             "build-temp",
             "t",
@@ -64,7 +63,6 @@ class build_rust(RustCommand):
         self.debug = None
         self.release = None
         self.qbuild = None
-        self.locked = None
         self.build_temp = None
         self.plat_name = None
         self.target = os.getenv("CARGO_BUILD_TARGET")
@@ -147,14 +145,9 @@ class build_rust(RustCommand):
             target_dir = os.path.join(target_dir, target_triple)
 
         quiet = self.qbuild or ext.quiet
-        locked = self.locked or ext.locked
         debug = self._is_debug_build(ext)
         cargo_args = self._cargo_args(
-            ext=ext,
-            target_triple=target_triple,
-            release=not debug,
-            quiet=quiet,
-            locked=locked,
+            ext=ext, target_triple=target_triple, release=not debug, quiet=quiet
         )
 
         if ext._uses_exec_binding():
@@ -483,7 +476,6 @@ class build_rust(RustCommand):
         target_triple: Optional[str],
         release: bool,
         quiet: bool,
-        locked: bool,
     ) -> List[str]:
         args = []
         if target_triple is not None:
@@ -496,9 +488,6 @@ class build_rust(RustCommand):
 
         if quiet:
             args.append("-q")
-
-        if locked:
-            args.append("--locked")
 
         elif self.verbose:
             # cargo only have -vv
@@ -515,6 +504,9 @@ class build_rust(RustCommand):
 
         if ext.args is not None:
             args.extend(ext.args)
+
+        if ext.cargo_manifest_args is not None:
+            args.extend(ext.cargo_manifest_args)
 
         return args
 

--- a/setuptools_rust/clean.py
+++ b/setuptools_rust/clean.py
@@ -17,6 +17,8 @@ class clean_rust(RustCommand):
     def run_for_extension(self, ext: RustExtension) -> None:
         # build cargo command
         args = ["cargo", "clean", "--manifest-path", ext.path]
+        if ext.locked:
+            args.append("--locked")
 
         if not ext.quiet:
             print(" ".join(args), file=sys.stderr)

--- a/setuptools_rust/clean.py
+++ b/setuptools_rust/clean.py
@@ -17,8 +17,8 @@ class clean_rust(RustCommand):
     def run_for_extension(self, ext: RustExtension) -> None:
         # build cargo command
         args = ["cargo", "clean", "--manifest-path", ext.path]
-        if ext.locked:
-            args.append("--locked")
+        if ext.cargo_manifest_args:
+            args.extend(ext.cargo_manifest_args)
 
         if not ext.quiet:
             print(" ".join(args), file=sys.stderr)

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -73,6 +73,7 @@ class RustExtension:
         rust_version: Minimum Rust compiler version required for this
             extension.
         quiet: Suppress Cargo's output.
+        locked: Require Cargo.lock is up to date.
         debug: Controls whether ``--debug`` or ``--release`` is passed to
             Cargo. If set to `None` (the default) then build type is
             automatic: ``inplace`` build will be a debug build, ``install``
@@ -113,6 +114,7 @@ class RustExtension:
         rustc_flags: Optional[List[str]] = None,
         rust_version: Optional[str] = None,
         quiet: bool = False,
+        locked: bool = False,
         debug: Optional[bool] = None,
         binding: Binding = Binding.PyO3,
         strip: Strip = Strip.No,
@@ -134,6 +136,7 @@ class RustExtension:
         self.binding = binding
         self.rust_version = rust_version
         self.quiet = quiet
+        self.locked = locked
         self.debug = debug
         self.strip = strip
         self.script = script
@@ -223,6 +226,8 @@ class RustExtension:
                 "--format-version",
                 "1",
             ]
+            if self.locked:
+                metadata_command.append("--locked")
             self._cargo_metadata = json.loads(subprocess.check_output(metadata_command))
         return self._cargo_metadata
 

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -68,12 +68,17 @@ class RustExtension:
         args: A list of extra arguments to be passed to Cargo. For example,
             ``args=["--no-default-features"]`` will disable the default
             features listed in ``Cargo.toml``.
+        cargo_manifest_args: A list of extra arguments to be passed to Cargo.
+            These arguments will be passed to every ``cargo`` command, not just
+            ``cargo build``. For valid options, see
+            `the Cargo Book <https://doc.rust-lang.org/cargo/commands/cargo-build.html#manifest-options>`_.
+            For example, ``cargo_manifest_args=["--locked"]`` will require
+            ``Cargo.lock`` files are up to date.
         features: A list of Cargo features to also build.
         rustc_flags: A list of additional flags passed to rustc.
         rust_version: Minimum Rust compiler version required for this
             extension.
         quiet: Suppress Cargo's output.
-        locked: Require Cargo.lock is up to date.
         debug: Controls whether ``--debug`` or ``--release`` is passed to
             Cargo. If set to `None` (the default) then build type is
             automatic: ``inplace`` build will be a debug build, ``install``
@@ -110,11 +115,11 @@ class RustExtension:
         target: Union[str, Dict[str, str]],
         path: str = "Cargo.toml",
         args: Optional[List[str]] = None,
+        cargo_manifest_args: Optional[List[str]] = None,
         features: Optional[List[str]] = None,
         rustc_flags: Optional[List[str]] = None,
         rust_version: Optional[str] = None,
         quiet: bool = False,
-        locked: bool = False,
         debug: Optional[bool] = None,
         binding: Binding = Binding.PyO3,
         strip: Strip = Strip.No,
@@ -132,11 +137,11 @@ class RustExtension:
         self.name = name
         self.target = target
         self.args = args
+        self.cargo_manifest_args = cargo_manifest_args
         self.rustc_flags = rustc_flags
         self.binding = binding
         self.rust_version = rust_version
         self.quiet = quiet
-        self.locked = locked
         self.debug = debug
         self.strip = strip
         self.script = script
@@ -226,8 +231,8 @@ class RustExtension:
                 "--format-version",
                 "1",
             ]
-            if self.locked:
-                metadata_command.append("--locked")
+            if self.cargo_manifest_args:
+                metadata_command.extend(self.cargo_manifest_args)
             self._cargo_metadata = json.loads(subprocess.check_output(metadata_command))
         return self._cargo_metadata
 

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from distutils import log
 from distutils.command.clean import clean
-from typing import List, Tuple, Type, cast
+from typing import List, Set, Tuple, Type, cast
 
 from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
@@ -49,12 +49,16 @@ def add_rust_extension(dist: Distribution) -> None:
             if self.vendor_crates:
                 manifest_paths = []
 
-                # Require lockfile to be up to date, if any one of our extensions
-                # requires it.
-                locked = False
+                # Collate cargo manifest options together.
+                # We can cheat here, as the only valid options are the simple strings
+                # --frozen, --locked, or --offline.
+                #
+                # https://doc.rust-lang.org/cargo/commands/cargo-build.html#manifest-options
+                cargo_manifest_args: Set[str] = set()
                 for ext in self.distribution.rust_extensions:
                     manifest_paths.append(ext.path)
-                    locked |= ext.locked
+                    if ext.cargo_manifest_args:
+                        cargo_manifest_args.union(ext.cargo_manifest_args)
 
                 if manifest_paths:
                     base_dir = self.distribution.get_fullname()
@@ -63,8 +67,8 @@ def add_rust_extension(dist: Distribution) -> None:
                     cargo_config_path = os.path.join(dot_cargo_path, "config.toml")
                     vendor_path = os.path.join(dot_cargo_path, "vendor")
                     command = ["cargo", "vendor"]
-                    if locked:
-                        command.append("--locked")
+                    if cargo_manifest_args:
+                        command.extend(sorted(cargo_manifest_args))
                     # additional Cargo.toml for extension 1..n
                     for extra_path in manifest_paths[1:]:
                         command.append("--sync")

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -58,7 +58,7 @@ def add_rust_extension(dist: Distribution) -> None:
                 for ext in self.distribution.rust_extensions:
                     manifest_paths.append(ext.path)
                     if ext.cargo_manifest_args:
-                        cargo_manifest_args.union(ext.cargo_manifest_args)
+                        cargo_manifest_args.update(ext.cargo_manifest_args)
 
                 if manifest_paths:
                     base_dir = self.distribution.get_fullname()

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -48,8 +48,14 @@ def add_rust_extension(dist: Distribution) -> None:
         def make_distribution(self) -> None:
             if self.vendor_crates:
                 manifest_paths = []
+
+                # Require lockfile to be up to date, if any one of our extensions
+                # requires it.
+                locked = False
                 for ext in self.distribution.rust_extensions:
                     manifest_paths.append(ext.path)
+                    locked |= ext.locked
+
                 if manifest_paths:
                     base_dir = self.distribution.get_fullname()
                     dot_cargo_path = os.path.join(base_dir, ".cargo")
@@ -57,6 +63,8 @@ def add_rust_extension(dist: Distribution) -> None:
                     cargo_config_path = os.path.join(dot_cargo_path, "config.toml")
                     vendor_path = os.path.join(dot_cargo_path, "vendor")
                     command = ["cargo", "vendor"]
+                    if locked:
+                        command.append("--locked")
                     # additional Cargo.toml for extension 1..n
                     for extra_path in manifest_paths[1:]:
                         command.append("--sync")


### PR DESCRIPTION
Closes #233 

This PR adds support for the `--locked` flag, wherever an external call to `cargo` is issued.

It is important this is supported in all callsites (not just in build), as all cargo calls have the potential to update the lockfile - for instance, `cargo metadata` will do so, which we call before `cargo build` when compiling the extension.

I'm not familiar with the codebase at all, so very happy to be given pointers on if I've missed anything, or the names/default values of the configuration options need to be considered more carefully.