### PR TITLE
Fix handling when BLDSHARED has no flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- If the sysconfig for `BLDSHARED` has no flags, `setuptools-rust` won't crash anymore. [#241](https://github.com/PyO3/setuptools-rust/pull/241)
+
 ## 1.3.0 (2022-04-26)
 
 ### Packaging

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -622,7 +622,7 @@ def _detect_unix_cross_compile_info() -> Optional["_CrossCompileInfo"]:
         linker = None
         linker_args = None
     else:
-        [linker, linker_args] = bldshared.split(maxsplit=1)
+        [linker, _, linker_args] = bldshared.partition(" ")
 
     return _CrossCompileInfo(host_type, cross_lib, linker, linker_args)
 


### PR DESCRIPTION
If there are no spaces in `bldshared` then `split` returns a list of length 1 and there is an error. OTOH `partition` always returns a tuple of length 3.

Split from #240.