### PR TITLE
Fix dylib_ext determination for wasm32

### DIFF
--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -258,10 +258,13 @@ class build_rust(RustCommand):
                         f"unable to find executable '{name}' in '{artifacts_dir}'"
                     )
         else:
-            if sys.platform == "win32" or sys.platform == "cygwin":
+            platform = sysconfig.get_platform()
+            if "win" in platform:
                 dylib_ext = "dll"
-            elif sys.platform == "darwin":
+            elif platform.startswith("macosx"):
                 dylib_ext = "dylib"
+            elif "wasm32" in platform:
+                dylib_ext = "wasm"
             else:
                 dylib_ext = "so"
 


### PR DESCRIPTION
Split off from #240. Ideally target determination should be split into a separate file and we should add unit tests for it. Maybe I will work on that in the future. There are a bunch of different checks for mac/windows/linux in here using different methods.