### PR TITLE
capture errors from `cargo metadata`

### DIFF
--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -210,9 +210,21 @@ class build_rust(RustCommand):
 
         # Execute cargo
         try:
-            output = subprocess.check_output(command, env=env, encoding="latin-1")
+            output = subprocess.check_output(
+                command, env=env, encoding="latin-1", stderr=subprocess.PIPE
+            )
         except subprocess.CalledProcessError as e:
-            raise CompileError(f"cargo failed with code: {e.returncode}\n{e.output}")
+            raise CompileError(
+                f"""
+                cargo failed with code: {e.returncode}
+
+                Output captured from stderr:
+                {e.stderr}
+
+                Output captured from stdout:
+                {e.stdout}
+                """
+            )
 
         except OSError:
             raise DistutilsExecError(

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -240,7 +240,25 @@ class RustExtension:
             ]
             if self.cargo_manifest_args:
                 metadata_command.extend(self.cargo_manifest_args)
-            self._cargo_metadata = json.loads(subprocess.check_output(metadata_command))
+
+            try:
+                payload = subprocess.check_output(
+                    metadata_command, encoding="latin-1", stderr=subprocess.PIPE
+                )
+            except subprocess.CalledProcessError as e:
+                raise DistutilsSetupError(
+                    f"""
+                    cargo metadata failed with code: {e.returncode}
+
+                    Output captured from stderr:
+                    {e.stderr}
+
+                    Output captured from stdout:
+                    {e.stdout}
+                    """
+                )
+
+            self._cargo_metadata = json.loads(payload)
         return self._cargo_metadata
 
     def _uses_exec_binding(self) -> bool:

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -257,8 +257,15 @@ class RustExtension:
                     {e.stdout}
                     """
                 )
-
-            self._cargo_metadata = json.loads(payload)
+            try:
+                self._cargo_metadata = json.loads(payload)
+            except json.decoder.JSONDecodeError as e:
+                raise DistutilsSetupError(
+                    f"""
+                    Error parsing output of cargo metadata as json; received:
+                    {payload}
+                    """
+                ) from e
         return self._cargo_metadata
 
     def _uses_exec_binding(self) -> bool:


### PR DESCRIPTION
Should fix #253.

The setup is copied largely from what's already in [`build.py`](https://github.com/PyO3/setuptools-rust/blob/v1.3.0/setuptools_rust/build.py#L212-L217), but using `DistutilsSetupError` instead of `CompileError` (in line with the rest of the error reporting in `extension.py`). Also, I don't think duplicating the `_prepare_build_environment` is necessary just for `cargo metadata`...?