### PR TITLE
respect `quiet` flag in `cargo metadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 - `Exec` binding `RustExtension` with `script=True` is deprecated in favor of `RustBin`. [#248](https://github.com/PyO3/setuptools-rust/pull/248)
+- `quiet` option will now suppress output of `cargo metadata`. [#256](https://github.com/PyO3/setuptools-rust/pull/256)
 
 ### Fixed
 - If the sysconfig for `BLDSHARED` has no flags, `setuptools-rust` won't crash anymore. [#241](https://github.com/PyO3/setuptools-rust/pull/241)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 - `Exec` binding `RustExtension` with `script=True` is deprecated in favor of `RustBin`. [#248](https://github.com/PyO3/setuptools-rust/pull/248)
+- Errors while calling `cargo metadata` are now reported back to the user [#254](https://github.com/PyO3/setuptools-rust/pull/254)
 - `quiet` option will now suppress output of `cargo metadata`. [#256](https://github.com/PyO3/setuptools-rust/pull/256)
 
 ### Fixed

--- a/setuptools_rust/private.py
+++ b/setuptools_rust/private.py
@@ -1,0 +1,33 @@
+import subprocess
+
+
+def format_called_process_error(e: subprocess.CalledProcessError) -> str:
+    """Helper to convert a CalledProcessError to an error message.
+
+    >>> format_called_process_error(subprocess.CalledProcessError(
+    ...     1, ['cargo', 'foo bar'], 'message', None
+    ... ))
+    "`cargo 'foo bar'` failed with code 1\\n-- Output captured from stdout:\\nmessage"
+    >>> format_called_process_error(subprocess.CalledProcessError(
+    ...    -1, ['cargo'], 'stdout', 'stderr'
+    ... ))
+    '`cargo` failed with code -1\\n-- Output captured from stdout:\\nstdout\\n-- Output captured from stderr:\\nstderr'
+    """
+    command = " ".join(_quote_whitespace(arg) for arg in e.cmd)
+    message = f"""`{command}` failed with code {e.returncode}
+-- Output captured from stdout:
+{e.stdout}"""
+
+    if e.stderr is not None:
+        message += f"""
+-- Output captured from stderr:
+{e.stderr}"""
+
+    return message
+
+
+def _quote_whitespace(string: str) -> str:
+    if " " in string:
+        return f"'{string}'"
+    else:
+        return string


### PR DESCRIPTION
Follow up to #254 to make the formatting reusable & tested, and respect `quiet` flag for stderr.