### PR TITLE
clarify semantics of `rustc_flags`, deprecate `native`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Errors while calling `cargo metadata` are now reported back to the user [#254](https://github.com/PyO3/setuptools-rust/pull/254)
 - `quiet` option will now suppress output of `cargo metadata`. [#256](https://github.com/PyO3/setuptools-rust/pull/256)
 - `setuptools-rust` will now match `cargo` behavior of not setting `--target` when the selected target is the rust host. [#258](https://github.com/PyO3/setuptools-rust/pull/258)
+- Deprecate `native` option of `RustExtension`. [#258](https://github.com/PyO3/setuptools-rust/pull/258)
 
 ### Fixed
 - If the sysconfig for `BLDSHARED` has no flags, `setuptools-rust` won't crash anymore. [#241](https://github.com/PyO3/setuptools-rust/pull/241)


### PR DESCRIPTION
I had a think about #235 and decided that it's not actually a bug, it's intended behaviour. The documentation now says you should use `RUSTFLAGS` environment variable if you want to modify the whole build.

Despite this, I did tidy up some of our internal flags like `-C linker=...` and the musl flags. Also added a `print` statement so that users can see what the final `RUSTFLAGS` are set to (if there are any and not `quiet`).

Finally, deprecated the `native` option in favour of letting users just configure this themselves with flags. I generally think it's not very useful as using `native` will produce extensions which may be less portable. So I don't think library authors will typically use it. 

Once this is merged (if it passes review), let's put out 1.4.0 release.