### PR TITLE
correctly apply quiet-flag to listen to stderr or not

### DIFF
--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -207,7 +207,7 @@ class build_rust(RustCommand):
 
         # Execute cargo
         try:
-            stderr = subprocess.PIPE if quiet else None
+            stderr = None if quiet else subprocess.PIPE
             output = subprocess.check_output(command, env=env, stderr=stderr, text=True)
         except subprocess.CalledProcessError as e:
             raise CompileError(format_called_process_error(e))

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -232,7 +232,7 @@ class RustExtension:
                 f.write(_SCRIPT_TEMPLATE.format(executable=repr(executable)))
 
     def _metadata(self, *, quiet: bool) -> "_CargoMetadata":
-        """Returns cargo metedata for this extension package.
+        """Returns cargo metadata for this extension package.
 
         Cached - will only execute cargo on first invocation.
         """
@@ -249,7 +249,7 @@ class RustExtension:
                 metadata_command.extend(self.cargo_manifest_args)
 
             try:
-                stderr = subprocess.PIPE if quiet else None
+                stderr = None if quiet else subprocess.PIPE
                 payload = subprocess.check_output(
                     metadata_command, stderr=stderr, encoding="latin-1"
                 )


### PR DESCRIPTION
Opening this for discussion (which is harder to do in closed issues & PRs).

Even with the brandnew, 1.4.0 I still do not get the logmessages (e.g. from `export CARGO_LOG=trace`) from the crashing `cargo metadata` call, c.f. #253. I think the condition in #256 ended up being the wrong way around - this tries to fix that.