### PR TITLE
build_rust: remove linker handling that broke cross compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 ### Changed
 - Locate cdylib artifacts by handling messages from cargo instead of searching target dir (fixes build on MSYS2). [#267](https://github.com/PyO3/setuptools-rust/pull/267)
+- No longer guess cross-compile environment using `HOST_GNU_TYPE` / `BUILD_GNU_TYPE` sysconfig variables. [#269](https://github.com/PyO3/setuptools-rust/pull/269)
+
+### Fixed
 - Fix RustBin build without wheel. [#273](https://github.com/PyO3/setuptools-rust/pull/273)
 - Fix RustBin setuptools install. [#275](https://github.com/PyO3/setuptools-rust/pull/275)
 

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import glob
 import json
 import os
-import pkg_resources
 import platform
 import shutil
 import subprocess
@@ -20,6 +19,7 @@ from distutils.sysconfig import get_config_var
 from pathlib import Path
 from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, cast
 
+import pkg_resources
 from setuptools.command.build import build as CommandBuild  # type: ignore[import]
 from setuptools.command.build_ext import build_ext as CommandBuildExt
 from setuptools.command.build_ext import get_abi3_suffix
@@ -131,23 +131,10 @@ class build_rust(RustCommand):
         self, ext: RustExtension, forced_target_triple: Optional[str] = None
     ) -> List["_BuiltModule"]:
 
-        target_info = self._detect_rust_target(forced_target_triple)
-        if target_info is not None:
-            target_triple = target_info.triple
-            cross_lib = target_info.cross_lib
-            linker = target_info.linker
-            # We're ignoring target_info.linker_args for now because we're not
-            # sure if they will always do the right thing. Might help with some
-            # of the OS-specific logic if it does.
-
-        else:
-            target_triple = None
-            cross_lib = None
-            linker = None
-
+        target_triple = self._detect_rust_target(forced_target_triple)
         rustc_cfgs = get_rustc_cfgs(target_triple)
 
-        env = _prepare_build_environment(cross_lib)
+        env = _prepare_build_environment()
 
         if not os.path.exists(ext.path):
             raise DistutilsFileError(
@@ -162,9 +149,6 @@ class build_rust(RustCommand):
         )
 
         rustflags = []
-
-        if linker is not None:
-            rustflags.extend(["-C", "linker=" + linker])
 
         if ext._uses_exec_binding():
             command = [
@@ -435,45 +419,12 @@ class build_rust(RustCommand):
 
     def _detect_rust_target(
         self, forced_target_triple: Optional[str] = None
-    ) -> Optional["_TargetInfo"]:
+    ) -> Optional[str]:
         assert self.plat_name is not None
-        cross_compile_info = _detect_unix_cross_compile_info()
-        if cross_compile_info is not None:
-            cross_target_info = cross_compile_info.to_target_info()
-            if forced_target_triple is not None:
-                if (
-                    cross_target_info is not None
-                    and not cross_target_info.is_compatible_with(forced_target_triple)
-                ):
-                    self.warn(
-                        f"Forced Rust target `{forced_target_triple}` is not "
-                        f"compatible with deduced Rust target "
-                        f"`{cross_target_info.triple}` - the built package "
-                        f" may not import successfully once installed."
-                    )
-
-                # Forcing the target in a cross-compile environment; use
-                # the cross-compile information in combination with the
-                # forced target
-                return _TargetInfo(
-                    forced_target_triple,
-                    cross_compile_info.cross_lib,
-                    cross_compile_info.linker,
-                    cross_compile_info.linker_args,
-                )
-            elif cross_target_info is not None:
-                return cross_target_info
-            else:
-                raise DistutilsPlatformError(
-                    "Don't know the correct rust target for system type "
-                    f"{cross_compile_info.host_type}. Please set the "
-                    "CARGO_BUILD_TARGET environment variable."
-                )
-
-        elif forced_target_triple is not None:
+        if forced_target_triple is not None:
             # Automatic target detection can be overridden via the CARGO_BUILD_TARGET
             # environment variable or --target command line option
-            return _TargetInfo.for_triple(forced_target_triple)
+            return forced_target_triple
 
         # Determine local rust target which needs to be "forced" if necessary
         local_rust_target = _adjusted_local_rust_target(self.plat_name)
@@ -485,7 +436,7 @@ class build_rust(RustCommand):
             # check for None first to avoid calling to rustc if not needed
             and local_rust_target != get_rust_host()
         ):
-            return _TargetInfo.for_triple(local_rust_target)
+            return local_rust_target
 
         return None
 
@@ -575,91 +526,6 @@ class _BuiltModule(NamedTuple):
     path: str
 
 
-class _TargetInfo(NamedTuple):
-    triple: str
-    cross_lib: Optional[str]
-    linker: Optional[str]
-    linker_args: Optional[str]
-
-    @staticmethod
-    def for_triple(triple: str) -> "_TargetInfo":
-        return _TargetInfo(triple, None, None, None)
-
-    def is_compatible_with(self, target: str) -> bool:
-        if self.triple == target:
-            return True
-
-        # the vendor field can be ignored, so x86_64-pc-linux-gnu is compatible
-        # with x86_64-unknown-linux-gnu
-        if _replace_vendor_with_unknown(self.triple) == target:
-            return True
-
-        return False
-
-
-class _CrossCompileInfo(NamedTuple):
-    host_type: str
-    cross_lib: Optional[str]
-    linker: Optional[str]
-    linker_args: Optional[str]
-
-    def to_target_info(self) -> Optional[_TargetInfo]:
-        """Maps this cross compile info to target info.
-
-        Returns None if the corresponding target information could not be
-        deduced.
-        """
-        # hopefully an exact match
-        targets = get_rust_target_list()
-        if self.host_type in targets:
-            return _TargetInfo(
-                self.host_type, self.cross_lib, self.linker, self.linker_args
-            )
-
-        # the vendor field can be ignored, so x86_64-pc-linux-gnu is compatible
-        # with x86_64-unknown-linux-gnu
-        without_vendor = _replace_vendor_with_unknown(self.host_type)
-        if without_vendor is not None and without_vendor in targets:
-            return _TargetInfo(
-                without_vendor, self.cross_lib, self.linker, self.linker_args
-            )
-
-        return None
-
-
-def _detect_unix_cross_compile_info() -> Optional["_CrossCompileInfo"]:
-    # See https://github.com/PyO3/setuptools-rust/issues/138
-    # This is to support cross compiling on *NIX, where plat_name isn't
-    # necessarily the same as the system we are running on.  *NIX systems
-    # have more detailed information available in sysconfig. We need that
-    # because plat_name doesn't give us information on e.g., glibc vs musl.
-    host_type = sysconfig.get_config_var("HOST_GNU_TYPE")
-    build_type = sysconfig.get_config_var("BUILD_GNU_TYPE")
-
-    if not host_type or host_type == build_type:
-        # not *NIX, or not cross compiling
-        return None
-
-    if "apple-darwin" in host_type and (build_type and "apple-darwin" in build_type):
-        # On macos and the build and host differ. This is probably an arm
-        # Python which was built on x86_64. Don't try to handle this for now.
-        # (See https://github.com/PyO3/setuptools-rust/issues/192)
-        return None
-
-    stdlib = sysconfig.get_path("stdlib")
-    assert stdlib is not None
-    cross_lib = os.path.dirname(stdlib)
-
-    bldshared = sysconfig.get_config_var("BLDSHARED")
-    if not bldshared:
-        linker = None
-        linker_args = None
-    else:
-        [linker, _, linker_args] = bldshared.partition(" ")
-
-    return _CrossCompileInfo(host_type, cross_lib, linker, linker_args)
-
-
 def _replace_vendor_with_unknown(target: str) -> Optional[str]:
     """Replaces vendor in the target triple with unknown.
 
@@ -672,7 +538,7 @@ def _replace_vendor_with_unknown(target: str) -> Optional[str]:
     return "-".join(components)
 
 
-def _prepare_build_environment(cross_lib: Optional[str]) -> Dict[str, str]:
+def _prepare_build_environment() -> Dict[str, str]:
     """Prepares environment variables to use when executing cargo build."""
 
     # Make sure that if pythonXX-sys is used, it builds against the current
@@ -692,10 +558,6 @@ def _prepare_build_environment(cross_lib: Optional[str]) -> Dict[str, str]:
             "PYO3_PYTHON": os.environ.get("PYO3_PYTHON", sys.executable),
         }
     )
-
-    if cross_lib:
-        env.setdefault("PYO3_CROSS_LIB_DIR", cross_lib)
-
     return env
 
 


### PR DESCRIPTION
The changes in #139 that attempt to fix issues in #138 break cross compilation of the Void Linux `python3-cryptography` package. (It probably would break any cross-compiled Python package that uses `setuptools-rust`, but `python3-cryptography` is the only package in Void that uses it.) The Void package build system, [xbps-src](https://github.com/void-linux/void-packages), sets up cross-compilation environments for several officially supported architectures and even more for which we do not provide prebuilt packages.

The changes in #139 are the incorrect solution to a problem that was caused by crossenv itself. The crossenv package appears to hack up the Python sysconfig file to reflect the cross-compilation environment. It then relies on the modified sysconfig data to determine how it should behave; while that might be acceptable in the package that creates the modified sysconfig, copying and relying on that behavior in `setuptools-rust` is wrong for several reasons:
- It enforces specific assumptions about the cross-compilation environment that are not guaranteed by anything but crossenv
- It relies on `HOST_GNU_TYPE` and `BUILD_GNU_TYPE` variables in Python sysconfig, which
    1. Appear to be largely undocumented (I can't seem to find authoritative descriptions of their purpose)
    2. Probably only exist in GNU setups, but their absence here leads to the potentially incorrect assumption that cross compilation is not taking place
    3. May describe the build-time configuration for the original *Python* interpreter rather than the anticipated environment in which packages using `setuptools-rust` are to be built. (For example, Void's Python packages for `aarch64{,-musl}` and `armv{6,7}l{,-musl}` all have sysconfig files that define these variables because the Python interpreter was cross compiled; however, that cross-compiled Python interpreter may be used for native builds of Python packages that use `setuptools-rust`, `setuptools-rust` will always assume that cross compilation is expected.)
- Attempting to pull the linker as argv[0] from `$BLDSHARED` and force its use in Rust builds will fail catastrophically if, *e.g.*, `$BLDSHARED` is a wrapper that relies on proper ordering of all following arguments.
- Even if argv[0] is the right linker, the current logic indiscriminately throws away the next argument but preserves all following arguments as `linker_args`, all of which are then ignored when actually building.
- The value of `PYO3_CROSS_LIB_DIR` is forced, potentially masking desired variables set in the user's environment with an incorrectly determined path.

The responsibility for correctly setting up the cross-compilation environment should lie in the system that constructs the environment, not fragile logic in packages like `setuptools-rust`. This PR removes most of the special-case handling imposed by #139 to restore cross-compilation support in general environments. The right fix for crossenv is to properly configure its build environment:
- The environment *or* the user can set `PYO3_CROSS_LIB_DIR` and `PYO3_CROSS_INCLUDE_DIR` as necessary to configure the proper paths for compilation.
- `CARGO_BUILD_TARGET` can be set to the expected target triple. (This is already recognized in the `build_rust` class.)
- The `CARGO_TARGET_<triple>_LINKER` environment variable can be set to the proper linker for cross-compilation.
- If the environment really needs additional customization, there is already preservation of `RUSTFLAGS` in `setuptools-rust`.

This implies that crossenv must do a little extra work by, *e.g.*, modifying the virtualenv activation script to set these variables (or providing its own activation script to do so before calling the stock activation script). However, doing this work is the right fix for this problem, not special-casing stuff in `setuptools-rust`.

cc: @benfogle (original author) @davidhewitt (did the merge)