### PR TITLE
Replace `setuptools-scm` with bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+commit = True
+tag = False
+current_version = 1.4.1
+
+[bumpversion:file:setup.cfg]
+
+[bumpversion:file:setuptools_rust/version.py]

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@ build
 target
 .pytest_cache
 *.egg-info
-setuptools_rust/version.py
 pyo3
 docs/_build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
-requires = ["setuptools>=62.4", "setuptools_scm[toml]>=3.4.3"]
+requires = ["setuptools>=62.4"]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-write_to = "setuptools_rust/version.py"
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = setuptools-rust
-version = attr: setuptools_rust.__version__
+version = 1.4.1
 author = Nikolay Kim
 author_email = fafhrd91@gmail.com
 license = MIT
@@ -28,7 +28,7 @@ classifiers =
 packages = setuptools_rust
 zip_safe = True
 install_requires = setuptools>=62.4; semantic_version>=2.8.2,<3; typing_extensions>=3.7.4.3
-setup_requires = setuptools>=62.4; setuptools_scm>=6.3.2
+setup_requires = setuptools>=62.4
 python_requires = >=3.7
 
 [options.entry_points]

--- a/setuptools_rust/version.py
+++ b/setuptools_rust/version.py
@@ -1,0 +1,4 @@
+__version__ = version = "1.4.1"
+__version_tuple__ = version_tuple = tuple(
+    map(lambda x: int(x[1]) if x[0] < 3 else x[1], enumerate(__version__.split(".")))
+)


### PR DESCRIPTION
See the discussion in https://github.com/PyO3/setuptools-rust/pull/271.

* patch release: `bumpversion patch`
* minor release: `bumpversion minor`
* major release: `bumpversion major`