### PR TITLE
Fix RustBin build without wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Changed
 - Locate cdylib artifacts by handling messages from cargo instead of searching target dir (fixes build on MSYS2). [#267](https://github.com/PyO3/setuptools-rust/pull/267)
+- Fix RustBin build without wheel. [#273](https://github.com/PyO3/setuptools-rust/pull/273)
 
 
 ## 1.4.1 (2022-07-05)


### PR DESCRIPTION
We shouldn't depend on wheel unless building a .whl file.

Fixes: [#1028](https://github.com/PyO3/maturin/issues/1028)