### PR TITLE
fix `get_lib_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fixed
+- Fix regression in `get_lib_name` crashing since 1.5.0. [#280](https://github.com/PyO3/setuptools-rust/pull/280)
+
 ## 1.5.0 (2022-08-09)
 ### Added
 - Add support for extension modules built for wasm32-unknown-emscripten with Pyodide. [#244](https://github.com/PyO3/setuptools-rust/pull/244)
@@ -11,7 +15,6 @@
 ### Fixed
 - Fix RustBin build without wheel. [#273](https://github.com/PyO3/setuptools-rust/pull/273)
 - Fix RustBin setuptools install. [#275](https://github.com/PyO3/setuptools-rust/pull/275)
-
 
 ## 1.4.1 (2022-07-05)
 ### Fixed

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -174,7 +174,7 @@ class RustExtension:
 
     def get_lib_name(self, *, quiet: bool) -> str:
         """Parse Cargo.toml to get the name of the shared library."""
-        metadata = self._metadata(quiet=quiet)
+        metadata = self.metadata(quiet=quiet)
         root_key = metadata["resolve"]["root"]
         [pkg] = [p for p in metadata["packages"] if p["id"] == root_key]
         name = pkg["targets"][0]["name"]

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3,16 +3,27 @@ from pathlib import Path
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
-from setuptools_rust.extension import RustBin
+from setuptools_rust.extension import RustBin, RustExtension
+
+SETUPTOOLS_RUST_DIR = Path(__file__).parent.parent
 
 
 @pytest.fixture()
 def hello_world_bin() -> RustBin:
-    setuptools_rust_dir = Path(__file__).parent.parent
     return RustBin(
         "hello-world",
         path=(
-            setuptools_rust_dir / "examples" / "hello-world" / "Cargo.toml"
+            SETUPTOOLS_RUST_DIR / "examples" / "hello-world" / "Cargo.toml"
+        ).as_posix(),
+    )
+
+
+@pytest.fixture()
+def namespace_package_extension() -> RustExtension:
+    return RustExtension(
+        "namespace_package.rust",
+        path=(
+            SETUPTOOLS_RUST_DIR / "examples" / "namespace_package" / "Cargo.toml"
         ).as_posix(),
     )
 
@@ -38,3 +49,11 @@ def test_metadata_cargo_log(
     captured = capfd.readouterr()
     assert captured.out == ""
     assert captured.err == ""
+
+
+def test_get_lib_name_namespace_package(
+    namespace_package_extension: RustExtension,
+) -> None:
+    assert (
+        namespace_package_extension.get_lib_name(quiet=True) == "namespace_package_rust"
+    )


### PR DESCRIPTION
before it fails with `TypeError: _metadata() missing 1 required positional argument: 'cargo'`