### PR TITLE
build: fix location of multiple exec artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Fixed
 - Fix regression in `get_lib_name` crashing since 1.5.0. [#280](https://github.com/PyO3/setuptools-rust/pull/280)
+- Fix regression in `Binding.Exec` builds with multiple executables not finding built executables since 1.5.0. [#283](https://github.com/PyO3/setuptools-rust/pull/283)
 
 ## 1.5.0 (2022-08-09)
 ### Added


### PR DESCRIPTION
Closes #281 

The call to `_find_cargo_artifacts` returned a generator, and then we searched this in a loop, causing unreliable results (e.g. the generator can be empty on the second turn of the loop). Changed `_find_cargo_artifacts` to return a list.