### PR TITLE
build: fix locating dylib artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fixed
+- Fix regression in `dylib` build artifacts not being found since 1.5.0. [#280](https://github.com/PyO3/setuptools-rust/pull/280)
+
 ## 1.5.1 (2022-08-14)
 ### Fixed
 - Fix regression in `get_lib_name` crashing since 1.5.0. [#280](https://github.com/PyO3/setuptools-rust/pull/280)


### PR DESCRIPTION
Fixes #286 

The logic to read cargo messages in 1.5.0 used `cdylib` always, though it looks like some users are using `dylib` and I don't see a reason to forbid that.