### PR TITLE
packaging: fix missing `examples/` from sdist

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,8 +23,11 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
+      # Install build and packaging dependencies.
+      # setuptools-scm is necessary for ensuring all files from VCS (such as
+      # examples) are in the sdist.
       run: |
-        pip install --upgrade pip setuptools wheel twine
+        pip install --upgrade pip setuptools wheel twine setuptools-scm
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 ### Fixed
-- Fix regression in `dylib` build artifacts not being found since 1.5.0. [#280](https://github.com/PyO3/setuptools-rust/pull/280)
+- Fix regression in `dylib` build artifacts not being found since 1.5.0. [#290](https://github.com/PyO3/setuptools-rust/pull/290)
+- Fix regression in sdist missing examples and other supplementary files since 1.5.0. [#291](https://github.com/PyO3/setuptools-rust/pull/291)
 
 ## 1.5.1 (2022-08-14)
 ### Fixed


### PR DESCRIPTION
Going to try installing `setuptools_scm` when building the sdist. Pushing a draft PR here to try it out.