### PR TITLE
Fix segfaults caused by modifying existing shared library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fixed
+- Fix a bug where rebuilding the library would cause any running processes using it to segfault. [#295](https://github.com/PyO3/setuptools-rust/pull/295)
+
 ## 1.5.2 (2022-09-19)
 ### Fixed
 - Fix regression in `dylib` build artifacts not being found since 1.5.0. [#290](https://github.com/PyO3/setuptools-rust/pull/290)

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -356,7 +356,7 @@ class build_rust(RustCommand):
             # doesn't work across file system boundaries.
             temp_ext_path = ext_path + "~"
             shutil.copyfile(dylib_path, temp_ext_path)
-            os.rename(temp_ext_path, ext_path)
+            os.replace(temp_ext_path, ext_path)
 
             if sys.platform != "win32" and not debug_build:
                 args = []

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -351,7 +351,7 @@ class build_rust(RustCommand):
             #
             # This is because shared libraries are memory mapped into processes
             # that use it, so modifying the shared library file (which is what
-            # `shutil.copyfile` does) means the next time a process calls into
+            # copying the file does) means the next time a process calls into
             # the shared library they get the updated library rather than the
             # original one, causing confusion and segfaults.
             #
@@ -365,7 +365,7 @@ class build_rust(RustCommand):
             except FileNotFoundError:
                 pass
 
-            shutil.copyfile(dylib_path, ext_path)
+            os.rename(dylib_path, ext_path)
 
             if sys.platform != "win32" and not debug_build:
                 args = []


### PR DESCRIPTION
When the built shared library is copied to the correct location, it actually *modifies* any existing shared library, which causes any running process using it to segfault.

To fix this, we first delete any existing shared library (which is safe to do) and then copy the newly built shared library to the correct location as a new file.

Related to #257

At least, this is the behaviour on Linux, I'm not sure about other OSes.