### PR TITLE
Pin Python used in emscripten CI to latest 3.10 patch version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,7 @@ jobs:
           cd node_modules/pyodide/
           node ../prettier/bin-prettier.js -w pyodide.asm.js
           EMSCRIPTEN_VERSION=$(node -p "require('./repodata.json').info.platform.split('_').slice(1).join('.')")
-          PYTHON_VERSION=3.10.2
+          PYTHON_VERSION=3.10
 
           echo "PYODIDE_VERSION=$PYODIDE_VERSION" >> $GITHUB_ENV
           echo "EMSCRIPTEN_VERSION=$EMSCRIPTEN_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
GitHub has been rolling out a change to have [`ubuntu-latest` workflows use Ubuntu 22.04](https://github.com/actions/runner-images/issues/6399). Once that change hit this repository, the `test-emscripten` CI job [started to fail](https://github.com/PyO3/setuptools-rust/actions/runs/3596085148). That job (added in #244) specifically pins the Python version to 3.10.2, which is [not available for Ubuntu 22.04](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json).

From what I can gather, 3.10.2 was chosen to match the version used by Pyodide for their CI tests. [Since then, Pyodide switched their CI to use the latest patch version of 3.10 ](https://github.com/pyodide/pyodide/pull/3309) (they also ran into the same incompatibility issue with Ubuntu 22.04 runners).

So: let's have the `test-emscripten` CI job use the latest patch version of Python 3.10, instead of pinning to any particular patch version.

Please note that the cache key used with `actions/cache@v3` doesn't need to be changed- the `python-path` output from `actions/setup-python@v4` includes the full Python version, so any patch version bumps to the Python version used will invalidate the cache.