### PR TITLE
Fix setup.cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Fixed
 - Fix a bug where rebuilding the library would cause any running processes using it to segfault. [#295](https://github.com/PyO3/setuptools-rust/pull/295)
+- Fix `setup.cfg` format for compatibility with "poetry==1.4.0". [#319](https://github.com/PyO3/setuptools-rust/pull/319)
 
 ## 1.5.2 (2022-09-19)
 ### Fixed

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,10 @@ classifiers =
 [options]
 packages = setuptools_rust
 zip_safe = True
-install_requires = setuptools>=62.4; semantic_version>=2.8.2,<3; typing_extensions>=3.7.4.3
+install_requires =
+    setuptools>=62.4
+    semantic_version>=2.8.2,<3
+    typing_extensions>=3.7.4.3
 setup_requires = setuptools>=62.4
 python_requires = >=3.7
 


### PR DESCRIPTION
We are using `setuptools-rust` as a build dependency of poetry-1.4.0 (in Ubuntun container of GitHub Actions).

```pyproject.toml
# ...
[tool.poetry.dependencies]
setuptools-rust = "*"

[build-system]
requires = ["setuptools", "setuptools_rust" , "wheel"]
build-backend = "setuptools.build_meta"
```

This cause some warnings like:

```
Preparing build environment with build-system requirements setuptools, setuptools_rust, wheelInvalid requirement (setuptools>=62.4; semantic_version>=2.8.2,<3; typing_extensions>=3.7.4.3) found in setuptools-rust-1.5.2 dependencies, skipping
```

This PR fix the warning.