### PR TITLE
Remove Python 3.6 trove classifier & add 3.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,11 +14,11 @@ classifiers =
     License :: OSI Approved :: MIT License
     Intended Audience :: Developers
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Development Status :: 5 - Production/Stable
     Operating System :: POSIX
     Operating System :: MacOS :: MacOS X


### PR DESCRIPTION
Support for Python 3.6 was dropped in https://github.com/PyO3/setuptools-rust/commit/49e9000c661ece1d8b4a6a56479aea760bf5516d but the Trove classifiers still list it as a compatible version. This PR fixes that.