### PR TITLE
chore(distutils): remove distutils usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Packaging
 - Include `py.typed` when packaging to denote that setuptools-rust includes type hints. [#338](https://github.com/PyO3/setuptools-rust/pull/338)
+- Remove direct imports from `distutils`. [#336](https://github.com/PyO3/setuptools-rust/pull/336)
 
 ## 1.6.0 (2023-04-27)
 ### Changed

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import tarfile
 from glob import glob
 from pathlib import Path

--- a/setuptools_rust/command.py
+++ b/setuptools_rust/command.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
-from distutils import log
-from distutils.errors import DistutilsPlatformError
-from typing import List, Optional
-
+import logging
 from setuptools import Command, Distribution
+from setuptools.errors import PlatformError
+from typing import List, Optional
 
 from .extension import RustExtension
 from .rustc_info import get_rust_version
+
+logger = logging.getLogger(__name__)
 
 
 class RustCommand(Command, ABC):
@@ -47,7 +48,7 @@ class RustCommand(Command, ABC):
 
     def run(self) -> None:
         if not self.extensions:
-            log.info("%s: no rust_extensions defined", self.get_command_name())
+            logger.info("%s: no rust_extensions defined", self.get_command_name())
             return
 
         all_optional = all(ext.optional for ext in self.extensions)
@@ -61,7 +62,7 @@ class RustCommand(Command, ABC):
                     ),
                     default=None,
                 )
-                raise DistutilsPlatformError(
+                raise PlatformError(
                     "can't find Rust compiler\n\n"
                     "If you are using an outdated pip version, it is possible a "
                     "prebuilt wheel is available for this package but pip is not able "
@@ -81,7 +82,7 @@ class RustCommand(Command, ABC):
                         else ""
                     )
                 )
-        except DistutilsPlatformError as e:
+        except PlatformError as e:
             if not all_optional:
                 raise
             else:
@@ -92,7 +93,7 @@ class RustCommand(Command, ABC):
             try:
                 rust_version = ext.get_rust_version()
                 if rust_version is not None and version not in rust_version:
-                    raise DistutilsPlatformError(
+                    raise PlatformError(
                         f"Rust {version} does not match extension requirement {rust_version}"
                     )
 

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -3,7 +3,7 @@ import os
 import re
 import subprocess
 import warnings
-from distutils.errors import DistutilsSetupError
+from setuptools.errors import SetupError
 from enum import IntEnum, auto
 from functools import lru_cache
 from typing import Any, Dict, List, NewType, Optional, Sequence, Union, cast
@@ -187,7 +187,7 @@ class RustExtension:
         try:
             return SimpleSpec(self.rust_version)
         except ValueError:
-            raise DistutilsSetupError(
+            raise SetupError(
                 "Can not parse rust compiler version: %s", self.rust_version
             )
 
@@ -198,16 +198,14 @@ class RustExtension:
         except ValueError:
             pass
         except IndexError:
-            raise DistutilsSetupError("Can not parse cargo profile from %s", self.args)
+            raise SetupError("Can not parse cargo profile from %s", self.args)
 
         # Handle `--profile=<profile>`
         profile_args = [p for p in self.args if p.startswith("--profile=")]
         if profile_args:
             profile = profile_args[0].split("=", 1)[1]
             if not profile:
-                raise DistutilsSetupError(
-                    "Can not parse cargo profile from %s", self.args
-                )
+                raise SetupError("Can not parse cargo profile from %s", self.args)
             return profile
         else:
             return None
@@ -259,11 +257,11 @@ class RustExtension:
                 metadata_command, stderr=stderr, encoding="latin-1"
             )
         except subprocess.CalledProcessError as e:
-            raise DistutilsSetupError(format_called_process_error(e))
+            raise SetupError(format_called_process_error(e))
         try:
             return cast(CargoMetadata, json.loads(payload))
         except json.decoder.JSONDecodeError as e:
-            raise DistutilsSetupError(
+            raise SetupError(
                 f"""
                 Error parsing output of cargo metadata as json; received:
                 {payload}

--- a/setuptools_rust/rustc_info.py
+++ b/setuptools_rust/rustc_info.py
@@ -1,5 +1,5 @@
 import subprocess
-from distutils.errors import DistutilsPlatformError
+from setuptools.errors import PlatformError
 from functools import lru_cache
 from typing import Dict, List, NewType, Optional
 
@@ -25,7 +25,7 @@ def get_rust_host() -> str:
     for line in _rust_version_verbose().splitlines():
         if line.startswith(_HOST_LINE_START):
             return line[len(_HOST_LINE_START) :].strip()
-    raise DistutilsPlatformError("Could not determine rust host")
+    raise PlatformError("Could not determine rust host")
 
 
 RustCfgs = NewType("RustCfgs", Dict[str, Optional[str]])


### PR DESCRIPTION
## Description

[`distutils` module usage is deprecated](https://peps.python.org/pep-0632/) since Python 3.10 and will be removed in Python 3.12, this PR gets rid of remaining usages of this module.

Replacements are taken from https://peps.python.org/pep-0632/#migration-advice and https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html.

## How this has been tested ?
To be checked