### PR TITLE
Pass include_dirs to cargo using env

### DIFF
--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -81,6 +81,7 @@ class build_rust(RustCommand):
         self.build_temp = None
         self.plat_name = None
         self.build_number = None
+        self.include_dirs = None
         self.target = os.getenv("CARGO_BUILD_TARGET")
         self.cargo = os.getenv("CARGO", "cargo")
 
@@ -151,6 +152,13 @@ class build_rust(RustCommand):
         rustc_cfgs = get_rustc_cfgs(target_triple)
 
         env = _prepare_build_environment()
+
+        if self.include_dirs:
+            env.update(
+                {
+                    "SETUPTOOLS_RUST_INCLUDE_DIRS": os.pathsep.join(self.include_dirs),
+                }
+            )
 
         if not os.path.exists(ext.path):
             raise DistutilsFileError(

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -153,6 +153,7 @@ def add_rust_extension(dist: Distribution) -> None:
                 options = self.distribution.get_cmdline_options().get("bdist_wheel", {})
                 plat_name = options.get("plat-name") or self.plat_name
                 build_rust.plat_name = plat_name
+                build_rust.include_dirs = self.include_dirs
                 build_rust.run()
 
             build_ext_base_class.run(self)


### PR DESCRIPTION
Sometimes the cargo build script needs to know the `include_dirs`, lets pass this in the `SETUPTOOLS_RUST_INCLUDE_DIRS` env variable.

See [#9132](https://github.com/pyca/cryptography/pull/9132) for example usage.