### PR TITLE
set macos link args to fix bin + lib combination

### DIFF
--- a/examples/hello-world-pyprojecttoml/Cargo.lock
+++ b/examples/hello-world-pyprojecttoml/Cargo.lock
@@ -25,6 +25,7 @@ name = "hello-world"
 version = "0.1.0"
 dependencies = [
  "pyo3",
+ "pyo3-build-config",
 ]
 
 [[package]]

--- a/examples/hello-world-pyprojecttoml/Cargo.toml
+++ b/examples/hello-world-pyprojecttoml/Cargo.toml
@@ -21,3 +21,6 @@ path = "rust/lib.rs"
 [[bin]]
 name = "print-hello"
 path = "rust/print_hello.rs"
+
+[build-dependencies]
+pyo3-build-config = "0.19.2"

--- a/examples/hello-world-pyprojecttoml/MANIFEST.in
+++ b/examples/hello-world-pyprojecttoml/MANIFEST.in
@@ -1,6 +1,6 @@
 graft python
 graft rust
 graft tests
-include Cargo.toml noxfile.py
+include Cargo.toml noxfile.py build.rs
 global-exclude */__pycache__/*
 global-exclude *.pyc

--- a/examples/hello-world-pyprojecttoml/build.rs
+++ b/examples/hello-world-pyprojecttoml/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}


### PR DESCRIPTION
Adding a `build.rs` with `pyo3_build_config::add_extension_module_link_args()` should fix the macOS failures in the new `pyproject.toml` example.

I had a look if there was a way for us to do this directly in `setuptools_rust`, but I couldn't see an obvious solution.