### PR TITLE
raise minimum python version to 3.8 and drop typing_extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", pypy-3.7, pypy-3.8, pypy-3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev", pypy-3.8, pypy-3.9]
         platform: [
           { os: "macos-latest",   python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
@@ -70,9 +70,6 @@ jobs:
           { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc" },
         ]
         exclude:
-          # No 32-bit pypy 3.7 on Windows
-          - python-version: pypy-3.7
-            platform: { os: "windows-latest", python-architecture: "x86" }
           # No 32-bit pypy 3.8 on Windows
           - python-version: pypy-3.8
             platform: { os: "windows-latest", python-architecture: "x86" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Packaging
+- Drop support for Python 3.7. [#357](https://github.com/PyO3/setuptools-rust/pull/357)
+
 ## 1.7.0 (2023-08-22)
 ### Packaging
 - Remove direct imports from `distutils`. [#336](https://github.com/PyO3/setuptools-rust/pull/336)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "setuptools-rust"
 version = "1.7.0"
 description = "Setuptools Rust extension plugin"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = ["distutils", "setuptools", "rust"]
 authors = [
     {name = "Nikolay Kim", email = "fafhrd91@gmail.com"},
@@ -13,7 +13,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -27,7 +26,6 @@ classifiers = [
 dependencies = [
     "setuptools>=62.4",
     "semantic_version>=2.8.2,<3",
-    "typing_extensions>=3.7.4.3",
     'tomli>=1.2.1; python_version<"3.11"'
 ]
 

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -16,7 +16,7 @@ from setuptools.errors import (
 )
 from sysconfig import get_config_var
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Optional, Set, Tuple, cast
+from typing import Dict, List, Literal, NamedTuple, Optional, Set, Tuple, cast
 
 import pkg_resources
 from semantic_version import Version
@@ -24,7 +24,6 @@ from setuptools import Distribution
 from setuptools.command.build import build as CommandBuild
 from setuptools.command.build_ext import build_ext as CommandBuildExt
 from setuptools.command.build_ext import get_abi3_suffix
-from typing_extensions import Literal
 
 from ._utils import format_called_process_error
 from .command import RustCommand

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -6,10 +6,19 @@ import warnings
 from setuptools.errors import SetupError
 from enum import IntEnum, auto
 from functools import lru_cache
-from typing import Any, Dict, List, NewType, Optional, Sequence, Union, cast
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    NewType,
+    Optional,
+    Sequence,
+    Union,
+    cast,
+)
 
 from semantic_version import SimpleSpec
-from typing_extensions import Literal
 
 from ._utils import format_called_process_error
 

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -4,7 +4,7 @@ import sys
 import sysconfig
 import logging
 
-from typing import List, Optional, Set, Tuple, Type, TypeVar, cast
+from typing import List, Literal, Optional, Set, Tuple, Type, TypeVar, cast
 from functools import partial
 
 from setuptools.command.build_ext import build_ext
@@ -14,7 +14,6 @@ from setuptools.command.install_lib import install_lib
 from setuptools.command.install_scripts import install_scripts
 from setuptools.command.sdist import sdist
 from setuptools.dist import Distribution
-from typing_extensions import Literal
 
 from .build import _get_bdist_wheel_cmd
 from .extension import Binding, RustBin, RustExtension, Strip


### PR DESCRIPTION
[typing.Literal](https://docs.python.org/3/library/typing.html#typing.Literal) was in python 3.8, so there isn't a need for this dependency on anything newer