### PR TITLE
Allow profile to be set by SETUPTOOLS_RUST_CARGO_PROFILE env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Drop support for Python 3.7. [#357](https://github.com/PyO3/setuptools-rust/pull/357)
 - Remove direct imports from `pkg_resources`. [#359](https://github.com/PyO3/setuptools-rust/pull/359)
 
+### Added
+- Add support for setting a custom cargo profile with the `SETUPTOOLS_RUST_CARGO_PROFILE` environment variable. [#364](https://github.com/PyO3/setuptools-rust/pull/364)
+
 ## 1.7.0 (2023-08-22)
 ### Packaging
 - Remove direct imports from `distutils`. [#336](https://github.com/PyO3/setuptools-rust/pull/336)

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -517,10 +517,10 @@ class build_rust(RustCommand):
         if target_triple is not None:
             args.extend(["--target", target_triple])
 
-        if release:
-            profile = ext.get_cargo_profile()
-            if not profile:
-                args.append("--release")
+        ext_profile = ext.get_cargo_profile()
+        env_profile = os.getenv("SETUPTOOLS_RUST_CARGO_PROFILE")
+        if release and not ext_profile and not env_profile:
+            args.append("--release")
 
         if quiet:
             args.append("-q")
@@ -540,6 +540,18 @@ class build_rust(RustCommand):
 
         if ext.args is not None:
             args.extend(ext.args)
+
+        if env_profile:
+            if ext_profile:
+                args = [p for p in args if not p.startswith("--profile=")]
+                while True:
+                    try:
+                        index = args.index("--profile")
+                        del args[index : index + 2]
+                    except ValueError:
+                        break
+
+            args.extend(["--profile", env_profile])
 
         if ext.cargo_manifest_args is not None:
             args.extend(ext.cargo_manifest_args)


### PR DESCRIPTION
This allows the profile to be set dynamically, without having to edit pyproject.toml/setup.py.