### PR TITLE
CI maintenance.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin
-      - uses: pypa/cibuildwheel@v2.3.1
+      - uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_BUILD: cp39-*
           CIBW_BEFORE_BUILD: pip install -U 'pip>=23.2.1' 'setuptools>=68.0.0' 'wheel<=0.37.1' && pip install -e . && pip list
@@ -320,10 +320,7 @@ jobs:
           #     setuptools needs to be upgraded before installing setuptools-rust
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_BUILD_FRONTEND: pip  # pip allows disabling isolation via env var
-          CIBW_ENVIRONMENT: PIP_NO_BUILD_ISOLATION=false
-          # ^-- necessary to use working copy of setuptools-rust,
-          #     (however PIP_NO_BUILD_ISOLATION is counter-intuitive: see pypa/pip#5735)
+          CIBW_BUILD_FRONTEND: "build; args: --no-isolation"
         with:
           package-dir: examples/namespace_package
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,9 +315,10 @@ jobs:
       - uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_BUILD: cp39-*
-          CIBW_BEFORE_BUILD: pip install -U 'pip>=23.2.1' 'setuptools>=68.0.0' 'wheel<=0.37.1' && pip install -e . && pip list
-          # ^-- cap on `wheel` is a workaround for pypa/auditwheel#436
-          #     setuptools needs to be upgraded before installing setuptools-rust
+          CIBW_BEFORE_BUILD: >
+            pip install -U 'pip>=23.2.1' 'setuptools>=68.0.0' 'wheel>=0.41.2' 'auditwheel>=5.4.0'
+            && pip install -e .
+            && pip list
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD_FRONTEND: "build; args: --no-isolation"

--- a/noxfile.py
+++ b/noxfile.py
@@ -174,7 +174,7 @@ def test_mingw(session: nox.Session):
         session.install("--no-build-isolation", str(examples / "html-py-ever"))
         session.run("pytest", str(examples / "html-py-ever"))
 
-        session.install("pytest", "cffi")
+        session.install("pytest", "cffi<1.16")
         session.install("--no-build-isolation", str(examples / "html-py-ever"))
         session.run("pytest", str(examples / "html-py-ever"))
 


### PR DESCRIPTION
This is a follow up on the previous CI changes.

- Avoid confusing `PIP_NO_BUILD_ISOLATION`.
  The latest version of `cibuildwheel` allows passing arguments directly to the build frontend CLI.
- Update `auditwheel` (via `pip`) to remove incompatibility with `wheel`'s latest version (due to de-vendoring of `auditwheel` by the container's OS package manager).
- Cap on `cffi<1.16` for mingw.
