### PR TITLE
fix readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
The 1.8.x releases are missing from readthedocs.io, I think it's due to an invalid configuration file.