### PR TITLE
fix cargo dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,22 @@ version: 2
 updates:
 
   - package-ecosystem: "cargo"
-    directory: "examples"
+    directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "docs"
     schedule:
       interval: "monthly"
+    groups:
+      docs-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ target
 *.egg-info
 pyo3
 docs/_build
+
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["examples/*"]

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-pyo3 = { version = "0.19.2", features = ["extension-module"] }
+pyo3 = { version = "0.20.0", features = ["extension-module"] }
 
 [lib]
 name = "_lib"  # private module to be nested into Python package,
@@ -143,7 +143,7 @@ python
 - `Cargo.toml` allow only one `[lib]` table per file.
   If you require multiple extension modules you will need to write multiple `Cargo.toml` files.
   Alternatively you can create a single private Rust top-level module that exposes
-  multiple submodules (using [PyO3's submodules](https://pyo3.rs/v0.19.2/module#python-submodules)),
+  multiple submodules (using [PyO3's submodules](https://pyo3.rs/v0.20.0/module#python-submodules)),
   which may also reduce the size of the build artifacts.
   You can always keep your extension modules private and wrap them in pure Python
   to have fine control over the public API.

--- a/examples/hello-world-setuppy/Cargo.toml
+++ b/examples/hello-world-setuppy/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "hello-world"
+name = "hello-world-setuppy"
 version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-pyo3 = { version = "0.19.2", features = ["extension-module"] }
+pyo3 = { version = "0.20.0", features = ["extension-module"] }
 
 [build-dependencies]
-pyo3-build-config = "0.19.2"
+pyo3-build-config = "0.20.0"
 
 [lib]
 # See https://github.com/PyO3/pyo3 for details


### PR DESCRIPTION
#383 inadvertently broke cargo configuration for dependabot. It was also out of date by missing some example directories. By adding a top-level `Cargo.toml` with `examples/*` as workspace members, we can ensure dependabot runs on the whole lot.

I also set up groups at the same time.