### PR TITLE
Fix CI with new cargo workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,56 @@ version: 2
 updates:
 
   - package-ecosystem: "cargo"
-    directory: "/"
+    directory: "examples/hello-world"
     schedule:
       interval: "monthly"
     groups:
-      rust-dependencies:
+      deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "examples/hello-world-script"
+    schedule:
+      interval: "monthly"
+    groups:
+      deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "examples/hello-world-setuppy"
+    schedule:
+      interval: "monthly"
+    groups:
+      deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "examples/html-py-ever"
+    schedule:
+      interval: "monthly"
+    groups:
+      deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "examples/namespace_package"
+    schedule:
+      interval: "monthly"
+    groups:
+      deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "examples/rust_with_cffi"
+    schedule:
+      interval: "monthly"
+    groups:
+      deps:
         patterns:
           - "*"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,0 @@
-[workspace]
-members = ["examples/*"]


### PR DESCRIPTION
I added a cargo workspace for the examples in #388, which is a little gross but IMO necessary to ensure that dependabot configuration reliably picks up all the examples.

This should fix CI following that tweak.