### PR TITLE
deprecate `RustExtension.py_limited_api`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Changed
+- Deprecate `py_limited_api` option to `RustExtension` in favour of always using `"auto"` to configure this from `bdist_wheel`. [#410](https://github.com/PyO3/setuptools-rust/pull/410)
+
 ## 1.8.1 (2023-10-30)
 ### Fixed
 - Fix regression in `install_extension` crashing since 1.8.0. [#380](https://github.com/PyO3/setuptools-rust/pull/380)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ target = "hello_world._lib"  # The last part of the name (e.g. "_lib") has to ma
                              # but you can add a prefix to nest it inside of a Python package.
 path = "Cargo.toml"      # Default value, can be omitted
 binding = "PyO3"         # Default value, can be omitted
-py-limited-api = "auto"  # Default value, can be omitted
 ```
 
 Each extension module should map directly into the corresponding `[lib]` table on the

--- a/examples/hello-world-setuppy/setup.py
+++ b/examples/hello-world-setuppy/setup.py
@@ -14,7 +14,6 @@ setup(
             #     in Cargo.toml and the function name in the `.rs` file,
             #     but you can add a prefix to nest it inside of a Python package.
             path="Cargo.toml",  # Default value, can be omitted
-            py_limited_api="auto",  # Default value, can be omitted
             binding=Binding.PyO3,  # Default value, can be omitted
         )
     ],

--- a/examples/hello-world/pyproject.toml
+++ b/examples/hello-world/pyproject.toml
@@ -19,7 +19,6 @@ find = { where = ["python"] }
 # Private Rust extension module to be nested into Python package
 target = "hello_world._lib"  # The last part of the name (e.g. "_lib") has to match lib.name in Cargo.toml,
                              # but you can add a prefix to nest it inside of a Python package.
-py-limited-api = "auto"  # Default value, can be omitted
 binding = "PyO3"  # Default value, can be omitted
 # See reference for RustExtension in https://setuptools-rust.readthedocs.io/en/latest/reference.html
 

--- a/examples/rust_with_cffi/setup.py
+++ b/examples/rust_with_cffi/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(where="python"),
     package_dir={"": "python"},
     rust_extensions=[
-        RustExtension("rust_with_cffi.rust", py_limited_api="auto"),
+        RustExtension("rust_with_cffi.rust"),
     ],
     cffi_modules=["cffi_module.py:ffi"],
     install_requires=["cffi"],

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -107,22 +107,7 @@ class RustExtension:
         optional: If it is true, a build failure in the extension will not
             abort the build process, and instead simply not install the failing
             extension.
-        py_limited_api: Similar to ``py_limited_api`` on
-            ``setuptools.Extension``, this controls whether the built extension
-            should be considered compatible with the PEP 384 "limited API".
-
-            - ``'auto'``: the ``py_limited_api`` option of
-              ``bdist_wheel`` will control whether the extension is
-              built as a limited api extension. The corresponding
-              ``pyo3/abi3-pyXY`` feature will be set accordingly.
-              This is the recommended setting, as it allows
-              to build a version-specific extension for best performance.
-
-            - ``True``: the extension is assumed to be compatible with the
-              limited abi. You must ensure this is the case (e.g. by setting
-              the ``pyo3/abi3`` feature).
-
-            - ``False``: the extension is version-specific.
+        py_limited_api: Deprecated.
     """
 
     def __init__(
@@ -177,6 +162,13 @@ class RustExtension:
         if binding == Binding.Exec and script:
             warnings.warn(
                 "`Binding.Exec` with `script=True` is deprecated, use `RustBin` instead.",
+                DeprecationWarning,
+            )
+
+        if self.py_limited_api != "auto":
+            warnings.warn(
+                "`RustExtension.py_limited_api` is deprecated, use [bdist_wheel] configuration "
+                "in `setup.cfg` or `DIST_EXTRA_CONFIG` to build abi3 wheels.",
                 DeprecationWarning,
             )
 


### PR DESCRIPTION
I'd like to simplify the `RustExtension` options a little further and remove the `py_limited_api` setting, as I think users should always use `"auto"` and use `[bdist_wheel]` configuration to set up an abi3 build.

If the PyO3 module should be built in abi3 mode for local (i.e. non-wheel) builds too, then that configuration is probably better placed in the `Cargo.toml` than in the `setuptools-rust` layer.

cc @alex as you implemented this setting originally, but I think `cryptography` has now also switched to `auto` mode.