### PR TITLE
Use base executable when it exists, to avoid recompiling when switching venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Changed
+ - Use the base interpreter path when running inside a virtual environment to avoid recompilation when switching between virtual environments. [#429](https://github.com/PyO3/setuptools-rust/pull/429)
+
 ## 1.9.0 (2024-02-24)
 ### Changed
 - Deprecate `py_limited_api` option to `RustExtension` in favour of always using `"auto"` to configure this from `bdist_wheel`. [#410](https://github.com/PyO3/setuptools-rust/pull/410)

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -610,9 +610,13 @@ def _replace_vendor_with_unknown(target: str) -> Optional[str]:
 def _prepare_build_environment() -> Dict[str, str]:
     """Prepares environment variables to use when executing cargo build."""
 
+    executable = getattr(sys, "_base_executable", sys.executable)
+    if not os.path.exists(executable):
+        executable = sys.executable
+
     # Make sure that if pythonXX-sys is used, it builds against the current
     # executing python interpreter.
-    bindir = os.path.dirname(sys.executable)
+    bindir = os.path.dirname(executable)
 
     env = os.environ.copy()
     env.update(
@@ -622,9 +626,9 @@ def _prepare_build_environment() -> Dict[str, str]:
             # interpreter from the path.
             "PATH": os.path.join(bindir, os.environ.get("PATH", "")),
             "PYTHON_SYS_EXECUTABLE": os.environ.get(
-                "PYTHON_SYS_EXECUTABLE", sys.executable
+                "PYTHON_SYS_EXECUTABLE", executable
             ),
-            "PYO3_PYTHON": os.environ.get("PYO3_PYTHON", sys.executable),
+            "PYO3_PYTHON": os.environ.get("PYO3_PYTHON", executable),
         }
     )
     return env


### PR DESCRIPTION
When using a requirements file compilation tool like pip-tools, a lot of temporary virtual environments are created, into which packages are installed. When a package uses setuptools-rust, the value of `sys.executable` keeps changing, which cause cargo to recompile quite a few crates (pyo3 and anything that depends on it). This slows things down quite a lot.

This PR uses the [semi-documented](https://docs.python.org/3/c-api/init_config.html#c.PyConfig.base_executable) `sys._base_executable` value, which points to the real Python interpreter when inside a venv. If it doesn't exist, or the provided path is not valid, we fall back to the current behaviour.

I tested this by running a requirements compilation, and checking for rustc invocations: There are a lot before this change, and none after (provided the rust package in question was already compiled).