### PR TITLE
Canonicalize base executable path when finding interpreter

### DIFF
--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -610,8 +610,10 @@ def _replace_vendor_with_unknown(target: str) -> Optional[str]:
 def _prepare_build_environment() -> Dict[str, str]:
     """Prepares environment variables to use when executing cargo build."""
 
-    executable = getattr(sys, "_base_executable", sys.executable)
-    if not os.path.exists(executable):
+    base_executable = getattr(sys, "_base_executable")
+    if base_executable and os.path.exists(base_executable):
+        executable = os.path.realpath(base_executable)
+    else:
         executable = sys.executable
 
     # Make sure that if pythonXX-sys is used, it builds against the current


### PR DESCRIPTION
Port across the change from https://github.com/PyO3/maturin/pull/2100 (based on https://github.com/PyO3/setuptools-rust/pull/429#issuecomment-2148702096) which allows this improvement to work with Poetry (thanks @messense!).