### PR TITLE
Delay imports of non-stdlib dependencies until time of use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Changed
  - Use the base interpreter path when running inside a virtual environment to avoid recompilation when switching between virtual environments. [#429](https://github.com/PyO3/setuptools-rust/pull/429)
+ - Delay import of dependencies until use to avoid import errors during a partially complete install when multiple packages are installing at once. [#437](https://github.com/PyO3/setuptools-rust/pull/437)
 
 ## 1.9.0 (2024-02-24)
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 dependencies = [
     "setuptools>=62.4",
     "semantic_version>=2.8.2,<3",
-    'tomli>=1.2.1; python_version<"3.11"'
 ]
 
 [project.entry-points."distutils.commands"]

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -190,6 +190,7 @@ class RustExtension:
             return None
         try:
             from semantic_version import SimpleSpec
+
             return SimpleSpec(self.rust_version)
         except ValueError:
             raise SetupError(

--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import re
@@ -14,11 +16,13 @@ from typing import (
     NewType,
     Optional,
     Sequence,
+    TYPE_CHECKING,
     Union,
     cast,
 )
 
-from semantic_version import SimpleSpec
+if TYPE_CHECKING:
+    from semantic_version import SimpleSpec
 
 from ._utils import format_called_process_error
 
@@ -185,6 +189,7 @@ class RustExtension:
         if self.rust_version is None:
             return None
         try:
+            from semantic_version import SimpleSpec
             return SimpleSpec(self.rust_version)
         except ValueError:
             raise SetupError(

--- a/setuptools_rust/rustc_info.py
+++ b/setuptools_rust/rustc_info.py
@@ -14,6 +14,7 @@ def get_rust_version() -> Optional[Version]:  # type: ignore[no-any-unimported]
         # first line of rustc -Vv is something like
         # rustc 1.61.0 (fe5b13d68 2022-05-18)
         from semantic_version import Version
+
         return Version(_rust_version().split(" ")[1])
     except (subprocess.CalledProcessError, OSError):
         return None

--- a/setuptools_rust/rustc_info.py
+++ b/setuptools_rust/rustc_info.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 import subprocess
 from setuptools.errors import PlatformError
 from functools import lru_cache
-from typing import Dict, List, NewType, Optional
+from typing import Dict, List, NewType, Optional, TYPE_CHECKING
 
-from semantic_version import Version
+if TYPE_CHECKING:
+    from semantic_version import Version
 
 
 def get_rust_version() -> Optional[Version]:  # type: ignore[no-any-unimported]
     try:
         # first line of rustc -Vv is something like
         # rustc 1.61.0 (fe5b13d68 2022-05-18)
+        from semantic_version import Version
         return Version(_rust_version().split(" ")[1])
     except (subprocess.CalledProcessError, OSError):
         return None

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -26,7 +26,10 @@ except ImportError:
 if sys.version_info[:2] >= (3, 11):
     from tomllib import load as toml_load
 else:
-    from tomli import load as toml_load
+    try:
+        from tomli import load as toml_load
+    except ImportError:
+        from setuptools.extern.tomli import load as toml_load
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This is a bit of a hack, but we do this to ensure that when setuptools loads entrypoint based hooks it cannot (will not?) crash.

The issue is that setuptools plugins are autoloaded, whether any given project uses them at all or not. So if setuptools-rust is installed, setuptools always tries to use it, and crashes if setuptools-rust is broken.
    
Of course, setuptools-rust can't be broken, because it's a wonderful project.

BUT.

As it happens, third-party vendors providing setuptools-rust can get into a situation where multiple packages need to be installed, including setuptools-rust, and also build yet other packages from source. In the middle of this, setuptools-rust itself could be installed but in "half-configured" state, i.e. its dependencies were queued for afterwards due to complicated dependency graph magic.

In such a scenario, it should be nominally all right to have an inert package installed, since if nothing actually uses setuptools-rust it doesn't need to *work* yet. And in fact, it is all right, as long as setuptools can import the autoloaded plugin hooks (and do nothing with them).

Bug: https://bugs.gentoo.org/933553
