### PR TITLE
tidy up argument handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
  - Use the base interpreter path when running inside a virtual environment to avoid recompilation when switching between virtual environments. [#429](https://github.com/PyO3/setuptools-rust/pull/429)
  - Delay import of dependencies until use to avoid import errors during a partially complete install when multiple packages are installing at once. [#437](https://github.com/PyO3/setuptools-rust/pull/437)
+ - Deprecate `--build-temp` argument to `build_rust` command (it does nothing). [#457](https://github.com/PyO3/setuptools-rust/pull/457)
 
 ## 1.9.0 (2024-02-24)
 ### Changed


### PR DESCRIPTION
Prompted by the current mypy failure, this tidies up argument handling a bit, and deprecates the useless argument `--build-temp`.