### PR TITLE
gate `base_executable` usage behind env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Support Python 3.13. [#446](https://github.com/PyO3/setuptools-rust/pull/446)
 
 ### Changed
- - Use the base interpreter path when running inside a virtual environment to avoid recompilation when switching between virtual environments. [#429](https://github.com/PyO3/setuptools-rust/pull/429)
+ - Add `SETUPTOOLS_RUST_PEP517_USE_BASE_PYTHON` environment variable to use the base interpreter path when running inside a virtual environment to avoid recompilation when switching between virtual environments. [#429](https://github.com/PyO3/setuptools-rust/pull/429)
  - Delay import of dependencies until use to avoid import errors during a partially complete install when multiple packages are installing at once. [#437](https://github.com/PyO3/setuptools-rust/pull/437)
 
 ## 1.9.0 (2024-02-24)

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -610,7 +610,10 @@ def _replace_vendor_with_unknown(target: str) -> Optional[str]:
 def _prepare_build_environment() -> Dict[str, str]:
     """Prepares environment variables to use when executing cargo build."""
 
-    base_executable = getattr(sys, "_base_executable")
+    base_executable = None
+    if os.getenv("SETUPTOOLS_RUST_PEP517_USE_BASE_PYTHON"):
+        base_executable = getattr(sys, "_base_executable")
+
     if base_executable and os.path.exists(base_executable):
         executable = os.path.realpath(base_executable)
     else:


### PR DESCRIPTION
Follow up to #429 to make this behaviour opt-in (by setting `SETUPTOOLS_RUST_PEP517_USE_BASE_PYTHON` to non-empty), resolving https://github.com/PyO3/setuptools-rust/pull/448#issuecomment-2201556072