### PR TITLE
Handle `wheel.bdist_wheel` deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           set -e
           cd examples/rust_with_cffi/
           python --version
-          pip install -U build cffi 'setuptools>=70.1,<74'  # TODO: Remove pin once python-cffi/cffi#117 is solved
+          pip install -U build cffi 'setuptools>=70.1'
           echo -e "[bdist_wheel]\npy_limited_api=cp39" > $DIST_EXTRA_CONFIG
           python -m build --no-isolation
           ls -la dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           rustup target add aarch64-apple-darwin
           rustup target add x86_64-apple-darwin
           cd examples/namespace_package
-          pip install build wheel
+          pip install build
           python -m build --no-isolation
           ls -l dist/
           pip install --force-reinstall dist/namespace_package*_universal2.whl
@@ -163,7 +163,7 @@ jobs:
           set -e
           cd examples/rust_with_cffi/
           python --version
-          pip install -U build cffi wheel
+          pip install -U build cffi 'setuptools>=70.1,<74'  # TODO: Remove pin once python-cffi/cffi#117 is solved
           echo -e "[bdist_wheel]\npy_limited_api=cp39" > $DIST_EXTRA_CONFIG
           python -m build --no-isolation
           ls -la dist/
@@ -180,7 +180,6 @@ jobs:
         run: |
           set -e
           cd examples/
-          pip install -U wheel
           python --version
           pip install rust_with_cffi/dist/rust_with_cffi*.whl
           python -c "from rust_with_cffi import rust; assert rust.rust_func() == 14"
@@ -235,7 +234,7 @@ jobs:
         run: |
           cd examples/namespace_package
           docker build -t cross-pyo3:aarch64-unknown-linux-gnu .
-          python -m pip install build wheel
+          python -m pip install build
           echo -e "[bdist_wheel]\nplat_name=manylinux2014_aarch64" > $DIST_EXTRA_CONFIG
           python -m build --no-isolation
           ls -la dist/
@@ -283,7 +282,7 @@ jobs:
           mkdir -p $PYO3_CROSS_LIB_DIR
           docker cp -L $(docker create --rm quay.io/pypa/manylinux2014_aarch64:latest):/opt/python/cp38-cp38 /opt/python
           cd examples/namespace_package
-          python -m pip install build wheel
+          python -m pip install build
           echo -e "[bdist_wheel]\nplat_name=manylinux2014_aarch64" > $DIST_EXTRA_CONFIG
           python -m build --no-isolation
           ls -la dist/
@@ -315,7 +314,7 @@ jobs:
         env:
           CIBW_BUILD: cp39-*
           CIBW_BEFORE_BUILD: >
-            pip install -U 'pip>=23.2.1' 'setuptools>=68.0.0' 'wheel>=0.41.2' 'auditwheel>=5.4.0'
+            pip install -U 'pip>=23.2.1' 'setuptools>=70.1.0' 'auditwheel>=5.4.0'
             && pip install -e .
             && pip list
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
@@ -354,7 +353,7 @@ jobs:
 
       - name: Install test dependencies
         shell: msys2 {0}
-        run: python -m pip install --upgrade nox pip wheel
+        run: python -m pip install --upgrade nox pip
 
       - name: Create libpython symlink
         shell: msys2 {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           rustup target add aarch64-apple-darwin
           rustup target add x86_64-apple-darwin
           cd examples/namespace_package
-          pip install build
+          pip install build 'setuptools>=70.1'
           python -m build --no-isolation
           ls -l dist/
           pip install --force-reinstall dist/namespace_package*_universal2.whl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.2 (2024-10-01)
+### Fixed
+- Fix deprecation warning from use of `wheel.bdist_wheel`.
+
 ## 1.10.1 (2024-08-04)
 ### Fixed
 - Fix regression in 1.10.0 where editable builds would be built in release mode

--- a/examples/hello-world-script/noxfile.py
+++ b/examples/hello-world-script/noxfile.py
@@ -7,7 +7,7 @@ SETUPTOOLS_RUST = dirname(dirname(dirname(__file__)))
 
 @nox.session()
 def test(session: nox.Session):
-    session.install(SETUPTOOLS_RUST, "wheel")
+    session.install(SETUPTOOLS_RUST)
     # Ensure build uses version of setuptools-rust under development
     session.install("--no-build-isolation", ".")
     # Test Rust binary

--- a/examples/hello-world-script/pyproject.toml
+++ b/examples/hello-world-script/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-rust"]
+requires = ["setuptools", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/examples/hello-world-setuppy/noxfile.py
+++ b/examples/hello-world-setuppy/noxfile.py
@@ -7,7 +7,7 @@ SETUPTOOLS_RUST = dirname(dirname(dirname(__file__)))
 
 @nox.session()
 def test(session: nox.Session):
-    session.install(SETUPTOOLS_RUST, "wheel")
+    session.install(SETUPTOOLS_RUST)
     # Ensure build uses version of setuptools-rust under development
     session.install("--no-build-isolation", ".")
     # Test Rust binary

--- a/examples/hello-world-setuppy/pyproject.toml
+++ b/examples/hello-world-setuppy/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-rust"]
+requires = ["setuptools", "setuptools-rust"]
 build-backend = "setuptools.build_meta"

--- a/examples/hello-world/noxfile.py
+++ b/examples/hello-world/noxfile.py
@@ -7,7 +7,7 @@ SETUPTOOLS_RUST = dirname(dirname(dirname(__file__)))
 
 @nox.session()
 def test(session: nox.Session):
-    session.install(SETUPTOOLS_RUST, "wheel", "build", "pytest")
+    session.install(SETUPTOOLS_RUST, "build", "pytest")
     # Ensure build works as intended
     session.install("--no-build-isolation", ".")
     # Test Rust binary

--- a/examples/html-py-ever/README.md
+++ b/examples/html-py-ever/README.md
@@ -96,7 +96,7 @@ test_bench_selector_python[/home/david/dev/setuptools-rust/examples/html-py-ever
 
 **building and installing**
 ```
-pip install setuptools-rust setuptools wheel
+pip install setuptools-rust setuptools
 python3 setup.py install --user
 ```
 

--- a/examples/html-py-ever/build-wheels.sh
+++ b/examples/html-py-ever/build-wheels.sh
@@ -7,7 +7,7 @@ export PATH="$HOME/.cargo/bin:$PATH"
 # Compile wheels
 for PYBIN in /opt/python/cp{37,38,39,310}*/bin; do
     rm -rf /io/build/
-    "${PYBIN}/pip" install -U setuptools setuptools-rust wheel
+    "${PYBIN}/pip" install -U setuptools setuptools-rust
     "${PYBIN}/pip" wheel /io/ -w /io/dist/ --no-deps
 done
 

--- a/examples/html-py-ever/noxfile.py
+++ b/examples/html-py-ever/noxfile.py
@@ -7,9 +7,7 @@ SETUPTOOLS_RUST = dirname(dirname(dirname(__file__)))
 
 @nox.session()
 def test(session: nox.Session):
-    session.install(
-        SETUPTOOLS_RUST, "wheel", "pytest", "pytest-benchmark", "beautifulsoup4"
-    )
+    session.install(SETUPTOOLS_RUST, "pytest", "pytest-benchmark", "beautifulsoup4")
     # Ensure build uses version of setuptools-rust under development
     session.install("--no-build-isolation", ".")
     # Test Python package

--- a/examples/html-py-ever/pyproject.toml
+++ b/examples/html-py-ever/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-rust"]
+requires = ["setuptools", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/examples/html-py-ever/requirements.txt
+++ b/examples/html-py-ever/requirements.txt
@@ -1,3 +1,2 @@
 setuptools-rust
-setuptools
-wheel
+setuptools>=70.1.0

--- a/examples/namespace_package/noxfile.py
+++ b/examples/namespace_package/noxfile.py
@@ -7,7 +7,7 @@ SETUPTOOLS_RUST = dirname(dirname(dirname(__file__)))
 
 @nox.session()
 def test(session: nox.Session):
-    session.install(SETUPTOOLS_RUST, "wheel")
+    session.install(SETUPTOOLS_RUST)
     # Ensure build uses version of setuptools-rust under development
     session.install("--no-build-isolation", ".[dev]")
     # Test Python package

--- a/examples/namespace_package/pyproject.toml
+++ b/examples/namespace_package/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-rust"]
+requires = ["setuptools", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/examples/rust_with_cffi/noxfile.py
+++ b/examples/rust_with_cffi/noxfile.py
@@ -14,6 +14,9 @@ def test(session: nox.Session):
     except nox.command.CommandFailed:
         session.skip("cffi not available on this platform")
 
+    session.install("setuptools<74.0.0")
+    # TODO: Remove custom installation once python-cffi/cffi#117 is solved
+
     # Ensure build uses version of setuptools-rust under development
     session.install("--no-build-isolation", ".")
     # Test Python package

--- a/examples/rust_with_cffi/noxfile.py
+++ b/examples/rust_with_cffi/noxfile.py
@@ -7,7 +7,7 @@ SETUPTOOLS_RUST = dirname(dirname(dirname(__file__)))
 
 @nox.session()
 def test(session: nox.Session):
-    session.install(SETUPTOOLS_RUST, "wheel", "pytest")
+    session.install(SETUPTOOLS_RUST, "pytest")
 
     try:
         session.install("cffi", "--only-binary=cffi")

--- a/examples/rust_with_cffi/noxfile.py
+++ b/examples/rust_with_cffi/noxfile.py
@@ -14,9 +14,6 @@ def test(session: nox.Session):
     except nox.command.CommandFailed:
         session.skip("cffi not available on this platform")
 
-    session.install("setuptools<74.0.0")
-    # TODO: Remove custom installation once python-cffi/cffi#117 is solved
-
     # Ensure build uses version of setuptools-rust under development
     session.install("--no-build-isolation", ".")
     # Test Python package

--- a/examples/rust_with_cffi/pyproject.toml
+++ b/examples/rust_with_cffi/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
-requires = ["setuptools", "setuptools-rust", "cffi"]
+requires = [
+  "setuptools<74.0.0", # TODO: Remove pin once python-cffi/cffi#117 is solved
+  "setuptools-rust",
+  "cffi"
+]
 build-backend = "setuptools.build_meta"

--- a/examples/rust_with_cffi/pyproject.toml
+++ b/examples/rust_with_cffi/pyproject.toml
@@ -1,7 +1,3 @@
 [build-system]
-requires = [
-  "setuptools<74.0.0", # TODO: Remove pin once python-cffi/cffi#117 is solved
-  "setuptools-rust",
-  "cffi"
-]
+requires = ["setuptools", "setuptools-rust", "cffi"]
 build-backend = "setuptools.build_meta"

--- a/noxfile.py
+++ b/noxfile.py
@@ -79,8 +79,9 @@ python3.11 -m pip install https://github.com/benfogle/crossenv/archive/refs/head
 python3.11 -m crossenv "/opt/python/cp311-cp311/bin/python3" --cc $TARGET_CC --cxx $TARGET_CXX --sysroot $TARGET_SYSROOT --env LIBRARY_PATH= --manylinux manylinux1 /venv
 . /venv/bin/activate
 
-build-pip install -U 'pip>=23.2.1' 'setuptools>=70.1.0' 'build>=1'
-cross-pip install -U 'pip>=23.2.1' 'setuptools>=70.1.0' 'build>=1'
+# TODO: Remove pin on setuptools once python-cffi/cffi#117 is solved
+build-pip install -U 'pip>=23.2.1' 'setuptools>=70.1,<74' 'build>=1'
+cross-pip install -U 'pip>=23.2.1' 'setuptools>=70.1,<74' 'build>=1'
 build-pip install cffi
 cross-expose cffi
 cross-pip install -e ../../

--- a/noxfile.py
+++ b/noxfile.py
@@ -79,9 +79,8 @@ python3.11 -m pip install https://github.com/benfogle/crossenv/archive/refs/head
 python3.11 -m crossenv "/opt/python/cp311-cp311/bin/python3" --cc $TARGET_CC --cxx $TARGET_CXX --sysroot $TARGET_SYSROOT --env LIBRARY_PATH= --manylinux manylinux1 /venv
 . /venv/bin/activate
 
-# TODO: Remove pin on setuptools once python-cffi/cffi#117 is solved
-build-pip install -U 'pip>=23.2.1' 'setuptools>=70.1,<74' 'build>=1'
-cross-pip install -U 'pip>=23.2.1' 'setuptools>=70.1,<74' 'build>=1'
+build-pip install -U 'pip>=23.2.1' 'setuptools>=70.1' 'build>=1'
+cross-pip install -U 'pip>=23.2.1' 'setuptools>=70.1' 'build>=1'
 build-pip install cffi
 cross-expose cffi
 cross-pip install -e ../../

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,7 @@ def test_examples(session: nox.Session):
 
 @nox.session(name="test-sdist-vendor")
 def test_sdist_vendor(session: nox.Session):
-    session.install(".", "build", "wheel")
+    session.install(".", "build")
     namespace_package = Path(__file__).parent / "examples" / "namespace_package"
     os.chdir(namespace_package)
     tmp = Path(session.create_tmp())
@@ -79,8 +79,8 @@ python3.11 -m pip install https://github.com/benfogle/crossenv/archive/refs/head
 python3.11 -m crossenv "/opt/python/cp311-cp311/bin/python3" --cc $TARGET_CC --cxx $TARGET_CXX --sysroot $TARGET_SYSROOT --env LIBRARY_PATH= --manylinux manylinux1 /venv
 . /venv/bin/activate
 
-build-pip install -U 'pip>=23.2.1' 'setuptools>=68.0.0' 'wheel>=0.41.1' 'build>=1'
-cross-pip install -U 'pip>=23.2.1' 'setuptools>=68.0.0' 'wheel>=0.41.1' 'build>=1'
+build-pip install -U 'pip>=23.2.1' 'setuptools>=70.1.0' 'build>=1'
+cross-pip install -U 'pip>=23.2.1' 'setuptools>=70.1.0' 'build>=1'
 build-pip install cffi
 cross-expose cffi
 cross-pip install -e ../../
@@ -171,7 +171,7 @@ def test_mingw(session: nox.Session):
     examples = Path(os.path.dirname(__file__)).absolute() / "examples"
 
     with patch.object(nox.command, "run", newrun):
-        session.install(".", "wheel")
+        session.install(".")
 
         session.install("--no-build-isolation", str(examples / "hello-world"))
         session.run("print-hello")

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -37,8 +37,8 @@ logger = logging.getLogger(__name__)
 
 
 try:
-    from wheel.bdist_wheel import bdist_wheel as CommandBdistWheel
-except ImportError:  # wheel installation might be deferred in PEP 517
+    from setuptools.command.bdist_wheel import bdist_wheel as CommandBdistWheel
+except ImportError:  # old version of setuptools
     from setuptools import Command as CommandBdistWheel
 
 

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 try:
     from setuptools.command.bdist_wheel import bdist_wheel as CommandBdistWheel
 except ImportError:  # old version of setuptools
-    from setuptools import Command as CommandBdistWheel
+    from setuptools import Command as CommandBdistWheel  # type: ignore[assignment]
 
 
 def _check_cargo_supports_crate_type_option() -> bool:

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -789,12 +789,12 @@ def _replace_cross_target_dir(path: str, ext: RustExtension, *, quiet: bool) -> 
     return path.replace(cross_target_dir, local_target_dir)
 
 
-def _get_bdist_wheel_cmd(  # type: ignore[no-any-unimported]
+def _get_bdist_wheel_cmd(
     dist: Distribution, create: Literal[True, False] = True
 ) -> Optional[CommandBdistWheel]:
     try:
         cmd_obj = dist.get_command_obj("bdist_wheel", create=create)
         cmd_obj.ensure_finalized()  # type: ignore[union-attr]
-        return cast(CommandBdistWheel, cmd_obj)  # type: ignore[no-any-unimported]
+        return cast(CommandBdistWheel, cmd_obj)
     except Exception:
         return None

--- a/setuptools_rust/build.py
+++ b/setuptools_rust/build.py
@@ -39,7 +39,10 @@ logger = logging.getLogger(__name__)
 try:
     from setuptools.command.bdist_wheel import bdist_wheel as CommandBdistWheel
 except ImportError:  # old version of setuptools
-    from setuptools import Command as CommandBdistWheel  # type: ignore[assignment]
+    try:
+        from wheel.bdist_wheel import bdist_wheel as CommandBdistWheel  # type: ignore[no-redef]
+    except ImportError:
+        from setuptools import Command as CommandBdistWheel  # type: ignore[assignment]
 
 
 def _check_cargo_supports_crate_type_option() -> bool:

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -254,7 +254,7 @@ def add_rust_extension(dist: Distribution) -> None:
     dist.cmdclass["install_scripts"] = install_scripts_rust_extension
 
     if bdist_wheel is not None:
-        bdist_wheel_base_class = cast(  # type: ignore[no-any-unimported]
+        bdist_wheel_base_class = cast(
             Type[bdist_wheel], dist.cmdclass.get("bdist_wheel", bdist_wheel)
         )
         bdist_wheel_options = bdist_wheel_base_class.user_options.copy()

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -19,9 +19,12 @@ from .build import _get_bdist_wheel_cmd
 from .extension import Binding, RustBin, RustExtension, Strip
 
 try:
-    from wheel.bdist_wheel import bdist_wheel
+    from setuptools.command.bdist_wheel import bdist_wheel
 except ImportError:
-    bdist_wheel = None
+    try:  # old version of setuptools
+        from wheel.bdist_wheel import bdist_wheel
+    except ImportError:
+        bdist_wheel = None
 
 if sys.version_info[:2] >= (3, 11):
     from tomllib import load as toml_load

--- a/setuptools_rust/setuptools_ext.py
+++ b/setuptools_rust/setuptools_ext.py
@@ -22,9 +22,9 @@ try:
     from setuptools.command.bdist_wheel import bdist_wheel
 except ImportError:
     try:  # old version of setuptools
-        from wheel.bdist_wheel import bdist_wheel
+        from wheel.bdist_wheel import bdist_wheel  # type: ignore[no-redef]
     except ImportError:
-        bdist_wheel = None
+        bdist_wheel = None  # type: ignore[assignment,misc]
 
 if sys.version_info[:2] >= (3, 11):
     from tomllib import load as toml_load


### PR DESCRIPTION
... by trying to import first from setuptools.

I also changed some of the test/CI related files to remove the (no-longer-)dependency on `wheel` (which also implies `setuptools>=70.1` in some cases).

Finally it was necessary to add a temporary workaround for python-cffi/cffi#117 (i.e. "pin" `setuptools<74` for some scenarios). This workaround can be removed once python-cffi/cffi#117 is tackled.

Closes #461