### PR TITLE
ci: add all examples directories to dependabot with glob

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,52 +2,8 @@ version: 2
 updates:
 
   - package-ecosystem: "cargo"
-    directory: "examples/hello-world"
-    schedule:
-      interval: "monthly"
-    groups:
-      deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "cargo"
-    directory: "examples/hello-world-script"
-    schedule:
-      interval: "monthly"
-    groups:
-      deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "cargo"
-    directory: "examples/hello-world-setuppy"
-    schedule:
-      interval: "monthly"
-    groups:
-      deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "cargo"
-    directory: "examples/html-py-ever"
-    schedule:
-      interval: "monthly"
-    groups:
-      deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "cargo"
-    directory: "examples/namespace_package"
-    schedule:
-      interval: "monthly"
-    groups:
-      deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "cargo"
-    directory: "examples/rust_with_cffi"
+    directories:
+      - "examples/*"
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
I think this will reduce the number of dependabot PRs significantly... 🤞 