### PR TITLE
ci: make mingw builds robust to version bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,7 @@ jobs:
 
       - name: Install test dependencies
         shell: msys2 {0}
-        run: python -m pip install --upgrade nox pip
+        run: python -m pip install --upgrade pip 'nox @ git+https://github.com/davidhewitt/nox.git@mingw-fix'
 
       - name: Create libpython symlink
         shell: msys2 {0}
@@ -409,8 +409,7 @@ jobs:
 
       - name: Test examples
         shell: msys2 {0}
-        run: |
-          PATH="$PATH:/c/Users/runneradmin/.cargo/bin" nox -s test-mingw
+        run: PATH="$PATH:/c/Users/runneradmin/.cargo/bin" nox -s test-examples
 
   test-emscripten:
     name: Test Emscripten

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,8 @@ jobs:
 
       - name: Install test dependencies
         shell: msys2 {0}
-        run: python -m pip install --upgrade pip 'nox @ git+https://github.com/davidhewitt/nox.git@mingw-fix'
+        # TODO: use stable nox after the targeted commit is released
+        run: python -m pip install --upgrade pip 'nox @ git+https://github.com/wntrblm/nox.git@60acbbe5574e4458931d96ac4733b91d0db1b50d'
 
       - name: Create libpython symlink
         shell: msys2 {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,9 @@ jobs:
 
       - name: Create libpython symlink
         shell: msys2 {0}
-        run: ln -s /${{ matrix.path }}/lib/libpython3.11.dll.a /${{ matrix.path }}/lib/libpython311.dll.a
+        run: |
+          PYTHON_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
+          ln -s /${{ matrix.path }}/lib/libpython3.${PYTHON_MINOR_VER}.dll.a /${{ matrix.path }}/lib/libpython3${PYTHON_MINOR_VER}.dll.a
 
       - name: Test examples
         shell: msys2 {0}

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,6 @@ import os
 from inspect import cleandoc as heredoc
 from glob import glob
 from pathlib import Path
-from unittest.mock import patch
 
 import nox
 import nox.command
@@ -154,45 +153,6 @@ def mypy(session: nox.Session):
 def test(session: nox.Session):
     session.install("pytest", ".")
     session.run("pytest", "setuptools_rust", "tests", *session.posargs)
-
-
-@nox.session(name="test-mingw")
-def test_mingw(session: nox.Session):
-    # manually re-implemented test-examples to workaround
-    # https://github.com/wntrblm/nox/issues/630
-
-    oldrun = nox.command.run
-
-    def newrun(*args, **kwargs):
-        # suppress "external" error on install
-        kwargs["external"] = True
-        oldrun(*args, **kwargs)
-
-    examples = Path(os.path.dirname(__file__)).absolute() / "examples"
-
-    with patch.object(nox.command, "run", newrun):
-        session.install(".")
-
-        session.install("--no-build-isolation", str(examples / "hello-world"))
-        session.run("print-hello")
-        session.run("sum-cli", "5", "7")
-        session.run("rust-demo", "5", "7")
-
-        session.install("pytest", "pytest-benchmark", "beautifulsoup4")
-        session.install("--no-build-isolation", str(examples / "html-py-ever"))
-        session.run("pytest", str(examples / "html-py-ever"))
-
-        session.install("--no-build-isolation", str(examples / "namespace_package"))
-        session.run("pytest", str(examples / "namespace_package"))
-
-        try:
-            session.install("cffi", "--only-binary=cffi")
-        except nox.command.CommandFailed:
-            # no compatible cffi currently available on mingw
-            pass
-        else:
-            session.install("--no-build-isolation", str(examples / "rust_with_cffi"))
-            session.run("pytest", str(examples / "rust_with_cffi"))
 
 
 @nox.session(name="test-examples-emscripten")


### PR DESCRIPTION
mingw changed to 3.12, hopefully this stops annual bitrot.