### PR TITLE
Update rust-cpython reference

### DIFF
--- a/setuptools_rust/extension.py
+++ b/setuptools_rust/extension.py
@@ -35,7 +35,7 @@ class Binding(IntEnum):
         PyO3: This is an extension built using
             `PyO3 <https://github.com/pyo3/pyo3>`_.
         RustCPython: This is an extension built using
-            `rust-cpython <https://github.com/dgrunwald/rust_cpython>`_.
+            `rust-cpython <https://github.com/dgrunwald/rust-cpython>`_.
         NoBinding: Bring your own bindings for the extension.
         Exec: Build an executable instead of an extension.
     """


### PR DESCRIPTION
# PR Summary
This small PR fixes the `rust-cpython` reference. Relevant page: https://setuptools-rust.readthedocs.io/en/latest/reference.html#setuptools_rust.Binding.RustCPython