### PR TITLE
Strip target suffix for cargo-zigbuild compatibility

### DIFF
--- a/setuptools_rust/rustc_info.py
+++ b/setuptools_rust/rustc_info.py
@@ -54,7 +54,7 @@ def get_rustc_cfgs(target_triple: Optional[str], env: Env) -> RustCfgs:
 def get_rust_target_info(target_triple: Optional[str], env: Env) -> List[str]:
     cmd = ["rustc", "--print", "cfg"]
     if target_triple:
-        cmd.extend(["--target", target_triple])
+        cmd.extend(["--target", target_triple.split('.')[0]])
     output = check_subprocess_output(cmd, env=env, text=True)
     return output.splitlines()
 


### PR DESCRIPTION
When using `cargo-zigbuild`, target triples may include additional suffixes like glibc versions (e.g. `aarch64-unknown-linux-gnu.2.17`). This change strips any suffix after the dot to ensure compatibility with rustc, which only accepts standard target triples.
